### PR TITLE
FUAM Fixed Overwrite Schema in case of missing columns

### DIFF
--- a/monitoring/fabric-unified-admin-monitoring/how-to/How_to_deploy_FUAM.md
+++ b/monitoring/fabric-unified-admin-monitoring/how-to/How_to_deploy_FUAM.md
@@ -208,6 +208,7 @@ You have deployed and configured FUAM.
     - If there is no workspace description on the whole tenant. In this case just add one workspace description. This will fix the error
     - In case there are no regular scheduled refreshes on the tenant, the execution for capacity refreshables can fail. This should be resolved by creating a scheduled refresh and running it multiple times
     - In case the are no delegated tenant settings set in one of the capacities, the extraction step will fail. You can remove this step if it is not needed in your tenant
+    - Try to run the "Init_FUAM_Lakehouse_Tables" notebook to automatically create missing columns
 
 # Other helpful resources
 - [Brief introduction to FUAM - Watch the video](https://youtu.be/CmHMOsQcMGI)

--- a/monitoring/fabric-unified-admin-monitoring/src/01_Transfer_Incremental_Inventory_Unit.Notebook/notebook-content.ipynb
+++ b/monitoring/fabric-unified-admin-monitoring/src/01_Transfer_Incremental_Inventory_Unit.Notebook/notebook-content.ipynb
@@ -46,7 +46,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:15.8188158Z\",\"execution_finish_time\":\"2025-02-14T23:48:16.0674097Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":\"2025-04-04T14:28:03.3445155Z\",\"execution_start_time\":\"2025-04-04T14:28:17.5691589Z\",\"execution_finish_time\":\"2025-04-04T14:28:21.1384747Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "8caaa26f-51a6-4f56-afc7-0e624a624ddb"
         },
@@ -94,7 +94,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:23.352958Z\",\"execution_finish_time\":\"2025-02-14T23:48:23.606149Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:21.1405245Z\",\"execution_finish_time\":\"2025-04-04T14:28:21.4229159Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "143ec38c-7bac-4822-956e-13da7a7e08f9"
         },
@@ -167,7 +167,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:26.9748581Z\",\"execution_finish_time\":\"2025-02-14T23:48:27.2950921Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:21.4248792Z\",\"execution_finish_time\":\"2025-04-04T14:28:21.7196458Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "a8234e9e-18fd-401d-adce-355ffeb25f2c"
         },
@@ -189,7 +189,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:29.4300969Z\",\"execution_finish_time\":\"2025-02-14T23:48:29.6611045Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:21.721415Z\",\"execution_finish_time\":\"2025-04-04T14:28:22.0545508Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "60a34ca7-d3bb-4bf1-89c3-e1818830f0d3"
         },
@@ -218,7 +218,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:34.4906555Z\",\"execution_finish_time\":\"2025-02-14T23:48:34.7273729Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:22.0566079Z\",\"execution_finish_time\":\"2025-04-04T14:28:22.4164595Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "990a7b62-7152-405a-982e-77ea97eca1de"
         },
@@ -253,7 +253,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:36.5178101Z\",\"execution_finish_time\":\"2025-02-14T23:48:38.9029648Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:22.4185943Z\",\"execution_finish_time\":\"2025-04-04T14:28:22.7362592Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "39637673-0528-44d1-8e44-1463d0ea810c"
         },
@@ -287,7 +287,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:40.2689957Z\",\"execution_finish_time\":\"2025-02-14T23:48:40.4951674Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:22.7383919Z\",\"execution_finish_time\":\"2025-04-04T14:28:23.1097288Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "2ec12b81-b0ae-4f70-bfc6-d3bf135e9976"
         },
@@ -340,7 +340,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:44.045315Z\",\"execution_finish_time\":\"2025-02-14T23:48:44.2853519Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:23.1119483Z\",\"execution_finish_time\":\"2025-04-04T14:28:23.4277724Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "7a4b4c30-8e58-4a73-a0dc-b105905e9f67"
         },
@@ -369,7 +369,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:46.4641269Z\",\"execution_finish_time\":\"2025-02-14T23:48:47.3418825Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:23.4298034Z\",\"execution_finish_time\":\"2025-04-04T14:28:24.8849179Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "570d4bd4-4b75-4e0c-8d46-00ed894d07b4"
         },
@@ -386,7 +386,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:49.0839187Z\",\"execution_finish_time\":\"2025-02-14T23:48:49.381349Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:24.8866913Z\",\"execution_finish_time\":\"2025-04-04T14:28:25.1857285Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "67207761-87b8-4702-8a6f-f93da9cb5e1d"
         },
@@ -431,7 +431,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:48:52.1998746Z\",\"execution_finish_time\":\"2025-02-14T23:49:04.3224549Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:25.1875431Z\",\"execution_finish_time\":\"2025-04-04T14:28:36.8087063Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "970e1622-7c8e-452c-9845-b1ec62b81e65"
         },
@@ -456,7 +456,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:49:06.859648Z\",\"execution_finish_time\":\"2025-02-14T23:49:07.0880529Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:36.8107582Z\",\"execution_finish_time\":\"2025-04-04T14:28:37.1052727Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "52d25e0b-c726-4b44-b9b1-c781b37ee7c5"
         },
@@ -486,7 +486,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:49:09.5599433Z\",\"execution_finish_time\":\"2025-02-14T23:49:12.003493Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:37.1072043Z\",\"execution_finish_time\":\"2025-04-04T14:28:39.5288161Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "f08955e0-ff38-475a-a06a-90d2858eb170"
         },
@@ -503,7 +503,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:49:13.2245259Z\",\"execution_finish_time\":\"2025-02-14T23:49:13.5339785Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:39.5306638Z\",\"execution_finish_time\":\"2025-04-04T14:28:39.8101192Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "c8966320-914a-4dc5-863a-9ae374e58056"
         },
@@ -558,7 +558,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-15T00:33:57.035962Z\",\"execution_finish_time\":\"2025-02-15T00:33:57.3259199Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}",
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:39.8119575Z\",\"execution_finish_time\":\"2025-04-04T14:28:40.1132024Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}",
                 "collapsed": false
             },
             "id": "fecf0668-78fb-4832-a0db-2cb3cec05c39"
@@ -578,7 +578,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:49:19.4514758Z\",\"execution_finish_time\":\"2025-02-14T23:49:19.6901463Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:40.1151854Z\",\"execution_finish_time\":\"2025-04-04T14:28:40.4094731Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "e7c074dc-6d16-41d6-b02c-f200bcfa4064"
         },
@@ -665,7 +665,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-15T00:20:38.0944778Z\",\"execution_finish_time\":\"2025-02-15T00:20:39.2699922Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}",
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:40.4114533Z\",\"execution_finish_time\":\"2025-04-04T14:28:40.7018125Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}",
                 "collapsed": false
             },
             "id": "ee5f5d54-2b81-4997-a864-664b31dbc5b5"
@@ -713,7 +713,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:10:55.946736Z\",\"execution_finish_time\":\"2025-01-08T07:10:56.2247805Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:40.7039168Z\",\"execution_finish_time\":\"2025-04-04T14:28:41.0408201Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "1e8e24da-ae29-4e2f-9866-d9b941314d93"
         },
@@ -722,9 +722,7 @@
             "source": [
                 "#### Power BI artifacts"
             ],
-            "metadata": {
-                "jp-MarkdownHeadingCollapsed": true
-            },
+            "metadata": {},
             "id": "0a1ad05d-edeb-4dbc-bd0a-a807bd1f4dd7"
         },
         {
@@ -787,7 +785,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:10:56.6430124Z\",\"execution_finish_time\":\"2025-01-08T07:10:56.8891219Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:41.0429262Z\",\"execution_finish_time\":\"2025-04-04T14:28:41.3733628Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "f26c0ff9-3bd0-4171-afa5-ab49d77e9def"
         },
@@ -881,7 +879,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:10:57.3077012Z\",\"execution_finish_time\":\"2025-01-08T07:10:57.5451782Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:41.3755284Z\",\"execution_finish_time\":\"2025-04-04T14:28:41.6846153Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "b784bb26-a22d-4f09-9c2f-1c74469d2bc3"
         },
@@ -943,7 +941,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:10:57.9722138Z\",\"execution_finish_time\":\"2025-01-08T07:10:58.2018489Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:41.6868699Z\",\"execution_finish_time\":\"2025-04-04T14:28:41.9884463Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "5271826f-aec2-4974-aaef-73dedd67c713"
         },
@@ -999,7 +997,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"Gellert Gintli\":{\"session_start_time\":null,\"execution_start_time\":\"2025-02-14T23:57:31.0558363Z\",\"execution_finish_time\":\"2025-02-14T23:57:31.3271743Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:41.9906012Z\",\"execution_finish_time\":\"2025-04-04T14:28:42.2766249Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "8ca13e56-8051-4d87-a100-44c7f3d55b29"
         },
@@ -1074,7 +1072,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:10:59.2658383Z\",\"execution_finish_time\":\"2025-01-08T07:10:59.5618724Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:42.2788783Z\",\"execution_finish_time\":\"2025-04-04T14:28:42.6287542Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "7ba42d2d-a4cb-405b-a6b5-d5d0a4706296"
         },
@@ -1122,7 +1120,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:10:59.9802356Z\",\"execution_finish_time\":\"2025-01-08T07:11:00.2330589Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:42.6307445Z\",\"execution_finish_time\":\"2025-04-04T14:28:42.9185865Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "6f2e0e8f-3611-41b5-8402-ffa8a86ba399"
         },
@@ -1179,7 +1177,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:00.617503Z\",\"execution_finish_time\":\"2025-01-08T07:11:00.895266Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:42.9207035Z\",\"execution_finish_time\":\"2025-04-04T14:28:43.2139347Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "3af5f408-654d-4c4a-be44-e91b02a8716d"
         },
@@ -1188,9 +1186,7 @@
             "source": [
                 "#### Fabric artifacts"
             ],
-            "metadata": {
-                "jp-MarkdownHeadingCollapsed": true
-            },
+            "metadata": {},
             "id": "39c592d1-8904-4041-8e0e-29478f559cc2"
         },
         {
@@ -1257,7 +1253,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:01.2663901Z\",\"execution_finish_time\":\"2025-01-08T07:11:01.5276686Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:43.2159223Z\",\"execution_finish_time\":\"2025-04-04T14:28:43.4916284Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "b76c1b92-edae-472b-875a-2291ac52ebc5"
         },
@@ -1315,7 +1311,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:01.9091928Z\",\"execution_finish_time\":\"2025-01-08T07:11:02.1481875Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:43.4938619Z\",\"execution_finish_time\":\"2025-04-04T14:28:43.810283Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "1f4b16cf-11fa-4a2f-b1ff-8b3c2e5d591d"
         },
@@ -1383,7 +1379,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:02.5439429Z\",\"execution_finish_time\":\"2025-01-08T07:11:02.7977094Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:43.8125121Z\",\"execution_finish_time\":\"2025-04-04T14:28:44.0971821Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "8d759825-699e-444b-88fd-384c9cc52e15"
         },
@@ -1448,7 +1444,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:03.1647622Z\",\"execution_finish_time\":\"2025-01-08T07:11:03.40841Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:44.0990691Z\",\"execution_finish_time\":\"2025-04-04T14:28:44.4330425Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "b43bf5dc-6416-4fd1-81a0-0643b704a0b4"
         },
@@ -1516,7 +1512,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:03.7722624Z\",\"execution_finish_time\":\"2025-01-08T07:11:04.0294028Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:44.4355294Z\",\"execution_finish_time\":\"2025-04-04T14:28:44.7340286Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "83e9b8c7-2c6f-455f-91d0-7e4930a75c6f"
         },
@@ -1584,7 +1580,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:04.4559602Z\",\"execution_finish_time\":\"2025-01-08T07:11:04.7050844Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:44.736151Z\",\"execution_finish_time\":\"2025-04-04T14:28:45.0527044Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "aa3708c3-666a-4458-82eb-49179deff619"
         },
@@ -1653,7 +1649,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:05.0946114Z\",\"execution_finish_time\":\"2025-01-08T07:11:05.3590915Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:45.0548956Z\",\"execution_finish_time\":\"2025-04-04T14:28:45.3891527Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "aa4308c5-5115-4840-8594-28b00b7fa9ab"
         },
@@ -1721,7 +1717,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:05.7774175Z\",\"execution_finish_time\":\"2025-01-08T07:11:06.0175248Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:45.3915239Z\",\"execution_finish_time\":\"2025-04-04T14:28:45.6851433Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "87f73940-2ff5-4a90-a8d0-a5bc51108385"
         },
@@ -1789,7 +1785,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:06.4188616Z\",\"execution_finish_time\":\"2025-01-08T07:11:06.6873904Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:45.6870475Z\",\"execution_finish_time\":\"2025-04-04T14:28:45.9702617Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "2ed9c2bd-5a8a-43c4-9dd1-a8220252d364"
         },
@@ -1857,7 +1853,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:07.1492583Z\",\"execution_finish_time\":\"2025-01-08T07:11:07.3852792Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:45.9725761Z\",\"execution_finish_time\":\"2025-04-04T14:28:46.3867588Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "8b649daa-f695-40a1-abc4-ef68870bbccd"
         },
@@ -1909,7 +1905,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:07.8279276Z\",\"execution_finish_time\":\"2025-01-08T07:11:08.0568101Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:46.3885832Z\",\"execution_finish_time\":\"2025-04-04T14:28:46.6674075Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "038bab1d-559c-407d-b2f0-40960beb3195"
         },
@@ -1959,7 +1955,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:08.4890681Z\",\"execution_finish_time\":\"2025-01-08T07:11:08.764018Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:46.669329Z\",\"execution_finish_time\":\"2025-04-04T14:28:46.9878048Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "8bf77e02-39f5-464c-8dc4-fabef8017b6a"
         },
@@ -1996,7 +1992,7 @@
                 "        # Transfer pandas df to spark df\n",
                 "        spark_df = spark.createDataFrame(df)\n",
                 "        #spark_df.printSchema()\n",
-                "        spark_df.write.mode(\"overwrite\").option(\"overwriteSchema\", \"true\").format(\"delta\").saveAsTable(table_name)"
+                "        spark_df.write.mode(\"overwrite\").option(\"mergeSchema\", \"true\").format(\"delta\").saveAsTable(table_name)"
             ],
             "outputs": [],
             "execution_count": null,
@@ -2005,7 +2001,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:09.1518617Z\",\"execution_finish_time\":\"2025-01-08T07:11:09.4137283Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:46.9897003Z\",\"execution_finish_time\":\"2025-04-04T14:28:47.2882342Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "03c8c285-bfe3-4087-b735-6f25bb8f5cb3"
         },
@@ -2028,7 +2024,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:11:09.8371177Z\",\"execution_finish_time\":\"2025-01-08T07:12:32.2700978Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:28:47.290064Z\",\"execution_finish_time\":\"2025-04-04T14:30:18.4517689Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "ab61b705-73ed-4c0c-a642-7225ed7b042c"
         },
@@ -2054,7 +2050,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:12:32.7185671Z\",\"execution_finish_time\":\"2025-01-08T07:12:32.9498428Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:30:18.4543467Z\",\"execution_finish_time\":\"2025-04-04T14:30:18.7407582Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "2f5e4e73-9145-4cff-b678-dc07cc38cdf7"
         },
@@ -2091,7 +2087,7 @@
                     "language": "python",
                     "language_group": "synapse_pyspark"
                 },
-                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-01-08T07:12:33.3547961Z\",\"execution_finish_time\":\"2025-01-08T07:12:34.142318Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
+                "cellStatus": "{\"System Administrator\":{\"session_start_time\":null,\"execution_start_time\":\"2025-04-04T14:30:18.7431461Z\",\"execution_finish_time\":\"2025-04-04T14:30:20.170062Z\",\"state\":\"finished\",\"livy_statement_state\":\"available\",\"normalized_state\":\"finished\"}}"
             },
             "id": "7f961aa6-cee5-4d0b-a9e3-a106bec76e8b"
         }

--- a/monitoring/fabric-unified-admin-monitoring/src/Init_FUAM_Lakehouse_Tables.Notebook/notebook-content.ipynb
+++ b/monitoring/fabric-unified-admin-monitoring/src/Init_FUAM_Lakehouse_Tables.Notebook/notebook-content.ipynb
@@ -1230,8 +1230,7 @@
                     "transient": {
                         "deleting": false
                     }
-                },
-                "jp-MarkdownHeadingCollapsed": true
+                }
             },
             "id": "9aa3046d-0899-4fb0-ba52-42ff313a04fa"
         },
@@ -1352,7 +1351,7 @@
                 "        col_type = row[\"Data_Type\"]\n",
                 "        if (col not in existing_table_cols) & ('struct' not in col_type) :\n",
                 "            print(f\"Add column {col} to table {table_name}\")\n",
-                "            spark.sql(f\" ALTER TABLE FUAM_Lakehouse.{table_name} ADD COLUMN {col} {col_type}\")\n"
+                "            spark.sql(f\" ALTER TABLE FUAM_Lakehouse.{table_name} ADD COLUMN `{col}` {col_type}\")\n"
             ],
             "outputs": [],
             "execution_count": null,

--- a/monitoring/fabric-unified-admin-monitoring/src/Load_FUAM_Data_E2E.DataPipeline/pipeline-content.json
+++ b/monitoring/fabric-unified-admin-monitoring/src/Load_FUAM_Data_E2E.DataPipeline/pipeline-content.json
@@ -346,7 +346,7 @@
             },
             "metric_workspace": {
                 "type": "string",
-                "defaultValue": "Microsoft Fabric Capacity Metrics v30"
+                "defaultValue": "Microsoft Fabric Capacity Metrics v35"
             },
             "metric_dataset": {
                 "type": "string",


### PR DESCRIPTION
In the Inventory notebook the overwriteSchema caused to produce missing columns for the semantic models in case some columns have not been returned by the Scanner API on a tenant. This caused the semantic model refresh to fail. Fixed this by changing to mergeSchema.
Additionally the Init Tables notebook is now able to handle special character columns for the Add Column mechansim