### PR TITLE
Added MaxCharLength Parameter to prevent truncation of the SQL Output

### DIFF
--- a/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
+++ b/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
@@ -75,7 +75,7 @@ GO
 
 # Generate the T-SQL command for schema and table creation from the existing datamart
 try {
-    $createSchema = Invoke-Sqlcmd -ServerInstance $datamartServerAddress -Database $datamartDatabaseName -AccessToken $accessToken -Query $sqlQuery -MaxCharLength 12000
+    $createSchema = Invoke-Sqlcmd -ServerInstance $datamartServerAddress -Database $datamartDatabaseName -AccessToken $accessToken -Query $sqlQuery -MaxCharLength 65535
 } catch {
     Write-Error "Failed to generate schema creation script: $_"
 }

--- a/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
+++ b/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
@@ -75,7 +75,7 @@ GO
 
 # Generate the T-SQL command for schema and table creation from the existing datamart
 try {
-    $createSchema = Invoke-Sqlcmd -ServerInstance $datamartServerAddress -Database $datamartDatabaseName -AccessToken $accessToken -Query $sqlQuery
+    $createSchema = Invoke-Sqlcmd -ServerInstance $datamartServerAddress -Database $datamartDatabaseName -AccessToken $accessToken -Query $sqlQuery -MaxCharLength 12000
 } catch {
     Write-Error "Failed to generate schema creation script: $_"
 }


### PR DESCRIPTION
For the Invoke-SQLCmd command in the file _schema_and_table_migration.ps1_ the generation of the T-SQL command for schema and table creation is truncated when the command length exceeds 4000 characters. To prevent that, the parameter "MaxCharLength" was added with a value of 65535 (max legth for the varchar(max)).