### PR TITLE
FUAM Release 2025.7.2

### DIFF
--- a/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
+++ b/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
@@ -1,6 +1,36 @@
 
+# 📦 Changelog – FUAM Release 2025.7.2
+
+Date: 2025-07-22
+
+## Important:
+We've updated the "Deploy_FUAM" notebook logic in Release 2025.7.1. 
+**Please download the latest version of the notebook, before you update FUAM in your environment.**
+
+### How to Update?
+Follow the [documented steps](https://github.com/microsoft/fabric-toolbox/blob/main/monitoring/fabric-unified-admin-monitoring/how-to/How_to_update_FUAM.md).
+
+
+## 🛠 Fixes
+
+- **Notebook Update**  
+    - An issue has been updated in notebook `01_Transfer_CapacityMetricData_Timepoints_Unit` 
+    - This fix addresses the following reported issue [#183](https://github.com/microsoft/fabric-toolbox/issues/183) by @alexisjensennz
+    - In case you already executed the main pipeline to fetch data with version 2025.7.1, please make sure you change the parameter of metrics_days_in_scope to a higher value in order to make sure the wrong data gets overwritten
+
+
+---
+
+
+We’re excited to see such strong engagement from the community and truly appreciate all the valuable feedback. With this update, we’ve made FUAM more robust and laid the groundwork for new features that were announced in the initial release. More versions are already in the works - stay tuned!
+
+---
+
+
+
 # 📦 Changelog – FUAM Release 2025.7.1
 
+Date: 2025-07-18
 
 ## Important:
 We've updated the "Deploy_FUAM" notebook logic. 

--- a/monitoring/fabric-unified-admin-monitoring/data/current_fuam_version.json
+++ b/monitoring/fabric-unified-admin-monitoring/data/current_fuam_version.json
@@ -1,6 +1,6 @@
 {
-    "current_fuam_version": "2025.7.1",
+    "current_fuam_version": "2025.7.2",
     "major_version": 2025,
     "minor_version": 7,
-    "build_version": 1
+    "build_version": 2
 }

--- a/monitoring/fabric-unified-admin-monitoring/how-to/How_to_update_FUAM.md
+++ b/monitoring/fabric-unified-admin-monitoring/how-to/How_to_update_FUAM.md
@@ -7,7 +7,8 @@ To update FUAM (Fabric Unified Admin Monitoring) to the latest version, follow t
 
 **Important:**
 
-- This update **overwrites all FUAM-provided items** based on the item name.
+- FUAM updates **overwrite all FUAM-provided items** based on the item name.
+- FUAM updates **do not** affect your collected data within the `FUAM_Lakehouse`, just the meta data will be overwritten.
 
 - If you **have made custom changes to pipelines, notebooks, semantic models, and reports**, please **create a backup or rename your custom items**
 

--- a/monitoring/fabric-unified-admin-monitoring/src/01_Transfer_CapacityMetricData_Timepoints_Unit.Notebook/notebook-content.ipynb
+++ b/monitoring/fabric-unified-admin-monitoring/src/01_Transfer_CapacityMetricData_Timepoints_Unit.Notebook/notebook-content.ipynb
@@ -35,7 +35,7 @@
         "from delta.tables import *"
       ],
       "outputs": [],
-      "execution_count": 1,
+      "execution_count": 28,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -51,13 +51,13 @@
         "## Parameters\n",
         "# These parameters will be overwritten while executing the notebook \n",
         "# from Load_FUAM_Data_E2E Pipeline\n",
-        "metric_days_in_scope = 3\n",
-        "metric_workspace = \"43e58404-650a-4fd3-b6e6-e3e0039e4a7e\"\n",
+        "metric_days_in_scope = 2\n",
+        "metric_workspace = \"0865c010-c5ba-4279-b2fc-51d85a369983\"\n",
         "metric_dataset = \"Fabric Capacity Metrics\"\n",
         "display_data = False"
       ],
       "outputs": [],
-      "execution_count": 2,
+      "execution_count": 29,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -79,7 +79,7 @@
         "gold_table_name_with_prefix = f\"Tables/{gold_table_name}\""
       ],
       "outputs": [],
-      "execution_count": 3,
+      "execution_count": 30,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -113,7 +113,7 @@
         "        exit"
       ],
       "outputs": [],
-      "execution_count": 4,
+      "execution_count": 31,
       "metadata": {
         "microsoft": {
           "language": "python",
@@ -135,7 +135,7 @@
         "        print(\"ERROR: Capacity Metrics data structure is not compatible or connection to capacity metrics is not possible.\")"
       ],
       "outputs": [],
-      "execution_count": 5,
+      "execution_count": 32,
       "metadata": {
         "microsoft": {
           "language": "python",
@@ -158,7 +158,7 @@
         "capacities = spark.createDataFrame(capacities)"
       ],
       "outputs": [],
-      "execution_count": 6,
+      "execution_count": 33,
       "metadata": {
         "microsoft": {
           "language": "python",
@@ -175,7 +175,7 @@
         "    display(capacities)"
       ],
       "outputs": [],
-      "execution_count": 7,
+      "execution_count": 34,
       "metadata": {
         "cellStatus": "",
         "collapsed": false,
@@ -215,7 +215,7 @@
         "    return dates\n"
       ],
       "outputs": [],
-      "execution_count": 8,
+      "execution_count": 35,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -237,7 +237,7 @@
         "    print(\"INFO: Silver table doesn't exist yet.\")"
       ],
       "outputs": [],
-      "execution_count": 9,
+      "execution_count": 36,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -280,6 +280,9 @@
         "\n",
         "            dax_query_primary = f\"\"\"\n",
         "            DEFINE\n",
+        "            \n",
+        "            MPARAMETER 'CapacityID' = \\\"{capacity_id}\\\"\n",
+        "\n",
         "            VAR __DS0Core = \n",
         "                    SUMMARIZECOLUMNS(\n",
         "                        Capacities[capacity Id],\n",
@@ -313,6 +316,9 @@
         "\n",
         "            dax_query_alternative = f\"\"\"\n",
         "            DEFINE\n",
+        "\n",
+        "            MPARAMETER 'CapacityID' = \\\"{capacity_id}\\\"\n",
+        "\n",
         "            VAR __DS0Core = \n",
         "                    SUMMARIZECOLUMNS(\n",
         "                        Capacities[capacityId],\n",
@@ -349,7 +355,7 @@
         "                dax_query = dax_query_primary\n",
         "            else:\n",
         "                dax_query = dax_query_alternative\n",
-        "\n",
+        "                \n",
         "            # Execute DAX query\n",
         "            capacity_df = fabric.evaluate_dax(workspace=metric_workspace, dataset=metric_dataset, dax_string=dax_query)\n",
         "            capacity_df.columns = ['CapacityId', 'TimePoint', 'BackgroundPercentage', 'InteractivePercentage', \n",
@@ -378,7 +384,7 @@
         "        continue"
       ],
       "outputs": [],
-      "execution_count": 10,
+      "execution_count": 37,
       "metadata": {
         "cellStatus": "",
         "collapsed": false,
@@ -397,7 +403,7 @@
         "silver_df = spark.sql(query)"
       ],
       "outputs": [],
-      "execution_count": 11,
+      "execution_count": 38,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -479,15 +485,12 @@
         "    silver_df.write.mode(\"append\").option(\"mergeSchema\", \"true\").format(\"delta\").saveAsTable(gold_table_name)"
       ],
       "outputs": [],
-      "execution_count": 13,
+      "execution_count": 39,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
           "language": "python",
           "language_group": "synapse_pyspark"
-        },
-        "advisor": {
-          "adviceMetadata": "{\"artifactId\":\"0483c441-2a52-3d47-886c-c92d889965bd\",\"activityId\":\"db166f29-3b2b-478c-a4c6-1238e156807c\",\"applicationId\":\"application_1752656520418_0001\",\"jobGroupId\":\"15\",\"advices\":{\"info\":2}}"
         }
       },
       "id": "435bc68f-09ba-4972-89b0-6a57f3fae9a6"
@@ -500,7 +503,7 @@
         "spark.sql(query)"
       ],
       "outputs": [],
-      "execution_count": 14,
+      "execution_count": 40,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -520,7 +523,7 @@
         "df.write.mode(\"overwrite\").format(\"delta\").saveAsTable(\"calendar_timepoints\")"
       ],
       "outputs": [],
-      "execution_count": 15,
+      "execution_count": 41,
       "metadata": {
         "cellStatus": "",
         "microsoft": {
@@ -529,20 +532,6 @@
         }
       },
       "id": "2da7008d-976e-4186-b855-b59c2fc63a55"
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "microsoft": {
-          "language": "python",
-          "language_group": "synapse_pyspark"
-        },
-        "cellStatus": ""
-      },
-      "id": "836fc875-aa86-4f4b-9321-01cbe0644caa"
     }
   ],
   "metadata": {


### PR DESCRIPTION
# 📦 Changelog – FUAM Release 2025.7.2

Date: 2025-07-22

## Important:
We've updated the "Deploy_FUAM" notebook logic in Release 2025.7.1. 
**Please download the latest version of the notebook, before you update FUAM in your environment.**

### How to Update?
Follow the [documented steps](https://github.com/microsoft/fabric-toolbox/blob/main/monitoring/fabric-unified-admin-monitoring/how-to/How_to_update_FUAM.md).


## 🛠 Fixes

- **Notebook Update**  
    - An issue has been updated in notebook `01_Transfer_CapacityMetricData_Timepoints_Unit` 
    - This fix addresses the following reported issue [#183](https://github.com/microsoft/fabric-toolbox/issues/183) by @alexisjensennz
    - In case you already executed the main pipeline to fetch data with version 2025.7.1, please make sure you change the parameter of metrics_days_in_scope to a higher value in order to make sure the wrong data gets overwritten
