### PR TITLE
Update datamart schema creation script to account for nvarchar(MAX) datatypes

### DIFF
--- a/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
+++ b/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
@@ -58,6 +58,7 @@ SELECT @sql = @sql + 'CREATE TABLE ['  + @schema + '].[' + TABLE_NAME + '] (' + 
         END +
         CASE
             WHEN DATA_TYPE IN ('float', 'money', 'text', 'ntext') THEN ''
+            WHEN DATA_TYPE = 'nvarchar' AND CHARACTER_MAXIMUM_LENGTH = -1 THEN '(MAX)'
             WHEN CHARACTER_MAXIMUM_LENGTH IS NOT NULL AND DATA_TYPE NOT IN ('bigint', 'datetime', 'date', 'time', 'datetime2', 'smalldatetime') THEN '(' + CAST(CHARACTER_MAXIMUM_LENGTH AS VARCHAR) + ')'
             WHEN NUMERIC_PRECISION IS NOT NULL AND DATA_TYPE NOT IN ('bigint') THEN '(' + CAST(NUMERIC_PRECISION AS VARCHAR) + ',' + CAST(NUMERIC_SCALE AS VARCHAR) + ')'
             ELSE ''


### PR DESCRIPTION
When the existing datamart has a column with datatype NVARCHAR(MAX), the CHARACTER_MAXIMUM_LENGTH is set to -1 within INFORMATION_SCHEMA.COLUMNS. 

When creating the new schema in a data warehouse, the existing script will attempt to create a column of datatype VARCHAR(-1), which will throw an error.

This fix takes that datatype into account and changes the datatype to VARCHAR(MAX)