### PR TITLE
column_name needs casting to max to address 8000 bytes limits

### DIFF
--- a/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
+++ b/accelerators/power-bi-to-fabric-data-warehouse-modernization/schema_and_table_migration.ps1
@@ -46,7 +46,7 @@ DECLARE @sql VARCHAR(MAX) = '',
 
 SELECT @sql = @sql + 'CREATE TABLE ['  + @schema + '].[' + TABLE_NAME + '] (' + CHAR(13) + CHAR(10) +
     STRING_AGG(
-        '[' + COLUMN_NAME + '] ' + 
+        '[' + cast(COLUMN_NAME as varchar(max)) + '] ' + 
         CASE 
             WHEN DATA_TYPE = 'nvarchar' THEN 'varchar'
             WHEN DATA_TYPE = 'nchar' THEN 'char'


### PR DESCRIPTION
There may be edge cases where the datamart contains a table which has wide column list, causing the STRING_AGG function to exceed the 8000-byte limit. When this happens, the following error is triggered:

Msg 9829, Level 16, State 1, Line 8  
STRING_AGG aggregation result exceeded the limit of 8000 bytes. Use LOB types to avoid result truncation.

Repro snippet:
<img width="1869" height="762" alt="image" src="https://github.com/user-attachments/assets/b6553963-e1ad-430d-bef5-ec26d521728a" />


To resolve this, I've added a cast function to extend the column length to varchar(max) at Line 49 in the script schema_and_table_migration.ps1:

