### PR TITLE
Fix Delay Parameter in Load Test Configuration

### DIFF
--- a/tools/FabricLoadTestTool/RunLoadTest.ipynb
+++ b/tools/FabricLoadTestTool/RunLoadTest.ipynb
@@ -108,7 +108,7 @@
     "        \"customdata\" : None,\n",
     "        \"effective_username\" : None,\n",
     "        \"iterations\" : iterations,\n",
-    "        \"delay_sec\" : 1,\n",
+    "        \"delay_sec\" : delay_sec,\n",
     "        \"loadtestId\" : loadtestId ,\n",
     "        \"threadId\" : 0 ,\n",
     "        \"concurrent_threads\" : concurrent_threads,\n",


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Updated the delay_sec parameter to use the variable delay_sec instead of a hardcoded value of 1. This change allows for more flexible configuration of the delay between iterations, improving the usability of the load test setup.

[https://github.com/microsoft/fabric-toolbox/issues/489](url)
[fix|close #489]

### Added

### Changed
Updated the delay_sec parameter to use the variable delay_sec instead of a hardcoded value of 1
### Deprecated

### Security

### Fixed

### Removed


## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [ ] Comment-based help added/updated.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated..
- [ ] Integration tests added/updated (where possible).
- [ ] Documentation added/updated (where applicable).
- [ ] Code follows the [contribution guidelines](../README.md#contributing).
