### PR TITLE
Power BI definition and data backup script

### DIFF
--- a/scripts/pbi-adls-backup/.gitignore
+++ b/scripts/pbi-adls-backup/.gitignore
@@ -1,0 +1,20 @@
+# Backup files
+*.abf
+
+# Log files
+*.log
+logs/
+
+# User-specific configuration (contains secrets)
+config.json
+
+# PowerShell module artifacts
+*.psm1.bak
+
+# IDE / Editor
+.vscode/
+*.code-workspace
+
+# OS
+Thumbs.db
+.DS_Store

--- a/scripts/pbi-adls-backup/Backup-PBISemanticModels.ps1
+++ b/scripts/pbi-adls-backup/Backup-PBISemanticModels.ps1
@@ -1,0 +1,290 @@
+#Requires -Modules MicrosoftPowerBIMgmt.Profile, MicrosoftPowerBIMgmt.Workspaces, MicrosoftPowerBIMgmt.Data, SqlServer
+
+<#
+.SYNOPSIS
+    Backs up Power BI Semantic Models to an attached ADLS Gen2 storage account.
+
+.DESCRIPTION
+    Iterates through Premium/Fabric workspaces in the organization. For each workspace:
+    1. Connects the workspace to the tenant's default Dataflow Storage (ADLS Gen2).
+    2. Loops through all semantic models in the workspace.
+    3. Triggers an automated backup (.abf file) using the XMLA endpoint.
+
+    Settings are loaded from config.json (if present) and can be overridden by
+    command-line parameters. Supports interactive authentication,
+    capacity/workspace/model filtering, and file-based logging.
+
+.PARAMETER ConfigFilePath
+    Optional. Path to a JSON configuration file. Defaults to ./config.json.
+    Settings in the file are used as defaults; CLI parameters override them.
+
+.PARAMETER CapacityFilter
+    Optional. An array of capacity display name patterns (supports wildcards) to include.
+    If omitted, all dedicated-capacity workspaces are processed regardless of capacity.
+
+.PARAMETER DataflowStorageAccountName
+    Optional. The display name (or wildcard pattern) of the ADLS Gen2 Dataflow Storage
+    Account to use. If omitted, the first tenant-level storage account is used.
+
+.PARAMETER WorkspaceFilter
+    Optional. An array of workspace name patterns (supports wildcards) to include.
+    If omitted, all dedicated-capacity workspaces are processed.
+
+.PARAMETER ExcludeWorkspaces
+    Optional. An array of workspace name patterns (supports wildcards) to exclude.
+    Evaluated before the include filter.
+
+.PARAMETER DatasetFilter
+    Optional. An array of semantic model name patterns (supports wildcards) to include.
+    If omitted, all models in each workspace are backed up.
+
+.PARAMETER LogFilePath
+    Optional. Path to a log file. Defaults to ./logs/Backup_<timestamp>.log.
+
+.EXAMPLE
+    # Interactive login, all workspaces
+    .\Backup-PBISemanticModels.ps1
+
+.EXAMPLE
+    # Back up only workspaces on a specific capacity
+    .\Backup-PBISemanticModels.ps1 -CapacityFilter "Sales Premium"
+
+.EXAMPLE
+    # Back up only workspaces matching "Sales*", exclude "Sales Archive"
+    .\Backup-PBISemanticModels.ps1 -WorkspaceFilter "Sales*" -ExcludeWorkspaces "Sales Archive"
+
+.EXAMPLE
+    # Use a custom config file
+    .\Backup-PBISemanticModels.ps1 -ConfigFilePath "C:\configs\production.json"
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ConfigFilePath,
+
+    [string[]]$CapacityFilter,
+
+    [string]$DataflowStorageAccountName,
+
+    [string[]]$WorkspaceFilter,
+
+    [string[]]$ExcludeWorkspaces,
+
+    [string[]]$DatasetFilter,
+
+    [string]$LogFilePath
+)
+
+# --- Setup ---
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $scriptDir "PBIBackupHelpers.psm1") -Force
+
+# --- Load Config ---
+if (-not $ConfigFilePath) {
+    $ConfigFilePath = Join-Path $scriptDir "config.json"
+}
+$config = Import-BackupConfig -Path $ConfigFilePath
+
+# Merge: CLI parameters override config values.
+# For arrays, use CLI value if explicitly provided, else config value.
+$boundParams = $PSBoundParameters
+
+if (-not $boundParams.ContainsKey('CapacityFilter') -and $config.capacityNames) {
+    $CapacityFilter = @($config.capacityNames)
+}
+if (-not $boundParams.ContainsKey('DataflowStorageAccountName') -and $config.dataflowStorageAccountName) {
+    $DataflowStorageAccountName = $config.dataflowStorageAccountName
+}
+if (-not $boundParams.ContainsKey('WorkspaceFilter') -and $config.workspaceFilter) {
+    $WorkspaceFilter = @($config.workspaceFilter)
+}
+if (-not $boundParams.ContainsKey('ExcludeWorkspaces') -and $config.excludeWorkspaces) {
+    $ExcludeWorkspaces = @($config.excludeWorkspaces)
+}
+if (-not $boundParams.ContainsKey('DatasetFilter') -and $config.datasetFilter) {
+    $DatasetFilter = @($config.datasetFilter)
+}
+$logTimestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+
+if (-not $LogFilePath) {
+    $logDir = if ($config.logDirectory) { $config.logDirectory } else { Join-Path $scriptDir "logs" }
+    $LogFilePath = Join-Path $logDir ("Backup_{0}.log" -f $logTimestamp)
+}
+else {
+    $logDir = Split-Path -Path $LogFilePath -Parent
+}
+
+# Derive success/failure CSV log paths using the same timestamp
+$SuccessLogPath = Join-Path $logDir ("Backup_{0}_successes.csv" -f $logTimestamp)
+$FailureLogPath = Join-Path $logDir ("Backup_{0}_failures.csv" -f $logTimestamp)
+
+# Ensure log directory exists and write CSV headers
+if ($logDir -and -not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+Set-Content -Path $SuccessLogPath -Value '"Workspace","SemanticModel","BackupFileName"'
+Set-Content -Path $FailureLogPath -Value '"Workspace","SemanticModel","Error"'
+
+# Counters for summary
+$totalWorkspaces = 0
+$totalModels = 0
+$totalSuccess = 0
+$totalFailed = 0
+
+# --- Authenticate ---
+Write-Log -Message "=== Power BI Semantic Model Backup ===" -Level Info -LogFilePath $LogFilePath
+
+Write-Log -Message "Authenticating to Power BI Service..." -Level Info -LogFilePath $LogFilePath
+$token = Connect-PBIServiceAuthenticated
+Write-Log -Message "Authentication successful." -Level Success -LogFilePath $LogFilePath
+
+# --- Get Dataflow Storage ---
+Write-Log -Message "Retrieving tenant Dataflow Storage Account..." -Level Info -LogFilePath $LogFilePath
+$storageParams = @{ LogFilePath = $LogFilePath }
+if ($DataflowStorageAccountName) {
+    $storageParams['StorageAccountName'] = $DataflowStorageAccountName
+}
+$dataflowStorageId = Get-TenantDataflowStorageId @storageParams
+
+# --- Get Workspaces ---
+Write-Log -Message "Fetching dedicated-capacity workspaces..." -Level Info -LogFilePath $LogFilePath
+$workspaces = Get-PowerBIWorkspace -Scope Organization -All | Where-Object { $_.IsOnDedicatedCapacity -eq $true }
+
+if (-not $workspaces) {
+    Write-Log -Message "No dedicated-capacity workspaces found." -Level Warning -LogFilePath $LogFilePath
+    return
+}
+
+Write-Log -Message "Found $($workspaces.Count) dedicated-capacity workspace(s)." -Level Info -LogFilePath $LogFilePath
+
+# --- Filter by Capacity ---
+if ($CapacityFilter -and $CapacityFilter.Count -gt 0) {
+    Write-Log -Message "Resolving capacity filter: $($CapacityFilter -join ', ')" -Level Info -LogFilePath $LogFilePath
+    $capacityIds = Get-CapacityIdsByName -CapacityFilter $CapacityFilter -LogFilePath $LogFilePath
+
+    if (-not $capacityIds -or $capacityIds.Count -eq 0) {
+        Write-Log -Message "No capacities matched the filter. Nothing to back up." -Level Warning -LogFilePath $LogFilePath
+        return
+    }
+
+    $workspaces = $workspaces | Where-Object { $_.CapacityId -in $capacityIds }
+
+    if (-not $workspaces) {
+        Write-Log -Message "No workspaces found on the matched capacities." -Level Warning -LogFilePath $LogFilePath
+        return
+    }
+
+    Write-Log -Message "$($workspaces.Count) workspace(s) on matched capacities. Applying name filters..." -Level Info -LogFilePath $LogFilePath
+}
+else {
+    Write-Log -Message "No capacity filter specified. Applying name filters..." -Level Info -LogFilePath $LogFilePath
+}
+
+# --- Process Workspaces ---
+foreach ($workspace in $workspaces) {
+
+    # Apply workspace filters
+    if (-not (Test-WorkspaceMatchesFilter -WorkspaceName $workspace.Name -IncludeFilter $WorkspaceFilter -ExcludeFilter $ExcludeWorkspaces)) {
+        Write-Log -Message "Skipping workspace '$($workspace.Name)' (filtered out)." -Level Info -LogFilePath $LogFilePath
+        continue
+    }
+
+    $totalWorkspaces++
+    Write-Log -Message "--- Processing Workspace: $($workspace.Name) ---" -Level Info -LogFilePath $LogFilePath
+
+    # Ensure ADLS connection
+    if ($PSCmdlet.ShouldProcess($workspace.Name, "Assign Dataflow Storage")) {
+        Connect-WorkspaceToDataflowStorage `
+            -WorkspaceId $workspace.Id `
+            -WorkspaceName $workspace.Name `
+            -DataflowStorageId $dataflowStorageId `
+            -LogFilePath $LogFilePath
+    }
+
+    # Get datasets
+    $datasets = Get-PowerBIDataset -WorkspaceId $workspace.Id
+
+    if (-not $datasets) {
+        Write-Log -Message "  No semantic models found in '$($workspace.Name)'." -Level Info -LogFilePath $LogFilePath
+        continue
+    }
+
+    # Build XMLA connection string — refresh token to avoid staleness
+    $token = Get-PBIAccessTokenString
+    $xmlaEndpoint = "powerbi://api.powerbi.com/v1.0/myorg/$($workspace.Name)"
+    $connectionString = "DataSource=$xmlaEndpoint;Password=$token;"
+
+    foreach ($dataset in $datasets) {
+
+        # Apply dataset filter
+        if (-not (Test-DatasetMatchesFilter -DatasetName $dataset.Name -IncludeFilter $DatasetFilter)) {
+            continue
+        }
+
+        $totalModels++
+        $backupFileName = "{0}_{1}.abf" -f $dataset.Name, (Get-Date -Format "yyyyMMdd_HHmmss")
+
+        # Escape backslashes and double-quotes for TMSL JSON
+        $escapedName = $dataset.Name -replace '\\', '\\\\' -replace '"', '\"'
+        $escapedFile = $backupFileName -replace '\\', '\\\\' -replace '"', '\"'
+
+        $tmsl = @"
+{
+  "backup": {
+    "database": "$escapedName",
+    "file": "$escapedFile",
+    "allowOverwrite": true,
+    "applyCompression": true
+  }
+}
+"@
+
+        if ($PSCmdlet.ShouldProcess("$($dataset.Name) in $($workspace.Name)", "XMLA Backup")) {
+            try {
+                Write-Log -Message "  Backing up: $($dataset.Name) -> $backupFileName" -Level Info -LogFilePath $LogFilePath
+                $result = Invoke-ASCmd -ConnectionString $connectionString -Query $tmsl -ErrorAction Stop
+                if ($result -match '<Error.*?Description="([^"]*)"') {
+                    Write-Log -Message "  XMLA error for '$($dataset.Name)': $($Matches[1])" -Level Error -LogFilePath $LogFilePath
+                    $escapedWs = $workspace.Name -replace '"', '""'
+                    $escapedDs = $dataset.Name -replace '"', '""'
+                    $escapedErr = $Matches[1] -replace '"', '""'
+                    Add-Content -Path $FailureLogPath -Value ('"' + $escapedWs + '","' + $escapedDs + '","' + $escapedErr + '"')
+                    $totalFailed++
+                }
+                else {
+                    Write-Log -Message "  Backup successful: $($dataset.Name)" -Level Success -LogFilePath $LogFilePath
+                    $escapedWs = $workspace.Name -replace '"', '""'
+                    $escapedDs = $dataset.Name -replace '"', '""'
+                    $escapedBf = $backupFileName -replace '"', '""'
+                    Add-Content -Path $SuccessLogPath -Value ('"' + $escapedWs + '","' + $escapedDs + '","' + $escapedBf + '"')
+                    $totalSuccess++
+                }
+            }
+            catch {
+                Write-Log -Message "  Failed to backup '$($dataset.Name)'. Error: $_" -Level Error -LogFilePath $LogFilePath
+                if ($_.Exception.InnerException) {
+                    Write-Log -Message "  Inner Exception: $($_.Exception.InnerException.Message)" -Level Error -LogFilePath $LogFilePath
+                }
+                $escapedWs = $workspace.Name -replace '"', '""'
+                $escapedDs = $dataset.Name -replace '"', '""'
+                $escapedErr = $_.Exception.Message -replace '"', '""'
+                Add-Content -Path $FailureLogPath -Value ('"' + $escapedWs + '","' + $escapedDs + '","' + $escapedErr + '"')
+                $totalFailed++
+            }
+        }
+    }
+}
+
+# --- Summary ---
+Write-Log -Message "=== Backup Summary ===" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Workspaces processed : $totalWorkspaces" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Models attempted     : $totalModels" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Successful backups   : $totalSuccess" -Level Success -LogFilePath $LogFilePath
+if ($totalFailed -gt 0) {
+    Write-Log -Message "Failed backups       : $totalFailed" -Level Error -LogFilePath $LogFilePath
+}
+Write-Log -Message "Log file             : $LogFilePath" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Success log          : $SuccessLogPath" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Failure log          : $FailureLogPath" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "=== Backup Complete ===" -Level Info -LogFilePath $LogFilePath

--- a/scripts/pbi-adls-backup/PBIBackupHelpers.psm1
+++ b/scripts/pbi-adls-backup/PBIBackupHelpers.psm1
@@ -1,0 +1,326 @@
+#Requires -Modules MicrosoftPowerBIMgmt.Profile
+
+<#
+.SYNOPSIS
+    Shared helper functions for Power BI Semantic Model Backup & Restore.
+#>
+
+function Write-Log {
+    <#
+    .SYNOPSIS
+        Writes a timestamped message to the console and optionally to a log file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [ValidateSet("Info", "Success", "Warning", "Error")]
+        [string]$Level = "Info",
+
+        [string]$LogFilePath
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logEntry = "[$timestamp] [$Level] $Message"
+
+    switch ($Level) {
+        "Info"    { Write-Host $logEntry }
+        "Success" { Write-Host $logEntry -ForegroundColor Green }
+        "Warning" { Write-Host $logEntry -ForegroundColor Yellow }
+        "Error"   { Write-Host $logEntry -ForegroundColor Red }
+    }
+
+    if ($LogFilePath) {
+        $logDir = Split-Path -Path $LogFilePath -Parent
+        if ($logDir -and -not (Test-Path $logDir)) {
+            New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        }
+        Add-Content -Path $LogFilePath -Value $logEntry
+    }
+}
+
+function Connect-PBIServiceAuthenticated {
+    <#
+    .SYNOPSIS
+        Authenticates to the Power BI Service using interactive login.
+    .OUTPUTS
+        The bearer token string (without "Bearer " prefix).
+    #>
+    [CmdletBinding()]
+    param()
+
+    Connect-PowerBIServiceAccount -ErrorAction Stop
+
+    return Get-PBIAccessTokenString
+}
+
+function Get-PBIAccessTokenString {
+    <#
+    .SYNOPSIS
+        Extracts the bearer token from the current Power BI session.
+    .OUTPUTS
+        The token string without the "Bearer " prefix.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $raw = (Get-PowerBIAccessToken -AsString -ErrorAction Stop)
+    return $raw -replace "^Bearer\s+", ""
+}
+
+function Test-NameMatchesPattern {
+    <#
+    .SYNOPSIS
+        Tests whether a name matches a pattern, handling PowerShell wildcard quirks.
+    .DESCRIPTION
+        Tries an exact (-eq) match first, then falls back to wildcard (-like).
+        This ensures names containing square brackets (e.g. "[specialk]") match
+        correctly even when the same text appears as a -like pattern, where
+        PowerShell would interpret brackets as a character-class wildcard.
+    #>
+    param(
+        [string]$Name,
+        [string]$Pattern
+    )
+
+    return ($Name -eq $Pattern) -or ($Name -like $Pattern)
+}
+
+function Get-TenantDataflowStorageId {
+    <#
+    .SYNOPSIS
+        Retrieves the ID of a tenant-level ADLS Gen2 Dataflow Storage Account.
+    .DESCRIPTION
+        When -StorageAccountName is provided, matches the display name using wildcard
+        comparison. When omitted, returns the first storage account.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$StorageAccountName,
+
+        [string]$LogFilePath
+    )
+
+    $endpoint = "https://api.powerbi.com/v1.0/myorg/dataflowStorageAccounts"
+    $response = Invoke-PowerBIRestMethod -Url $endpoint -Method Get | ConvertFrom-Json
+
+    if (-not $response.value -or $response.value.Count -eq 0) {
+        throw "No Dataflow Storage Accounts are attached at the tenant level. Please attach an ADLS Gen2 account in the Power BI Admin Portal."
+    }
+
+    if ($StorageAccountName) {
+        $match = $response.value | Where-Object { Test-NameMatchesPattern -Name $_.name -Pattern $StorageAccountName }
+
+        if (-not $match) {
+            $available = ($response.value | ForEach-Object { $_.name }) -join ', '
+            throw "No Dataflow Storage Account matched '$StorageAccountName'. Available accounts: $available"
+        }
+
+        # Take the first match if the wildcard returns multiple
+        $storageId = @($match)[0].id
+        $storageName = @($match)[0].name
+        Write-Log -Message "Matched Dataflow Storage Account: $storageName (ID: $storageId)" -Level Info -LogFilePath $LogFilePath
+    }
+    else {
+        $storageId = $response.value[0].id
+        Write-Log -Message "Using first Dataflow Storage Account (ID: $storageId)" -Level Info -LogFilePath $LogFilePath
+    }
+
+    return $storageId
+}
+
+function Connect-WorkspaceToDataflowStorage {
+    <#
+    .SYNOPSIS
+        Ensures a workspace is connected to the tenant's ADLS Gen2 Dataflow Storage Account.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkspaceId,
+
+        [Parameter(Mandatory)]
+        [string]$WorkspaceName,
+
+        [Parameter(Mandatory)]
+        [string]$DataflowStorageId,
+
+        [string]$LogFilePath
+    )
+
+    $endpoint = "https://api.powerbi.com/v1.0/myorg/groups/$WorkspaceId/AssignToDataflowStorage"
+    $body = @{ dataflowStorageId = $DataflowStorageId } | ConvertTo-Json
+
+    try {
+        Invoke-PowerBIRestMethod -Url $endpoint -Method Post -Body $body -ContentType "application/json" -ErrorAction Stop
+        Write-Log -Message "Workspace '$WorkspaceName': ADLS Gen2 connection verified/assigned." -Level Success -LogFilePath $LogFilePath
+    }
+    catch {
+        $errorMsg = $_.Exception.Message
+        $statusCode = $null
+        if ($_.Exception.Response) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        if ($statusCode -eq 400 -or $statusCode -eq 403 -or $errorMsg -match '\b(already assigned|StorageAccountAlreadyAssigned)\b') {
+            Write-Log -Message "Workspace '$WorkspaceName': ADLS connection skipped (may already be assigned or requires elevated privileges)." -Level Warning -LogFilePath $LogFilePath
+        }
+        else {
+            Write-Log -Message "Workspace '$WorkspaceName': Failed to assign ADLS storage. Error: $errorMsg" -Level Error -LogFilePath $LogFilePath
+        }
+    }
+}
+
+function Test-WorkspaceMatchesFilter {
+    <#
+    .SYNOPSIS
+        Checks if a workspace name matches include/exclude filter criteria.
+    .OUTPUTS
+        $true if the workspace should be processed, $false if it should be skipped.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$WorkspaceName,
+
+        [string[]]$IncludeFilter,
+
+        [string[]]$ExcludeFilter
+    )
+
+    # Check exclude list first
+    if ($ExcludeFilter) {
+        foreach ($pattern in $ExcludeFilter) {
+            if (Test-NameMatchesPattern -Name $WorkspaceName -Pattern $pattern) {
+                return $false
+            }
+        }
+    }
+
+    # If no include filter is specified, include everything
+    if (-not $IncludeFilter -or $IncludeFilter.Count -eq 0) {
+        return $true
+    }
+
+    # Check include list
+    foreach ($pattern in $IncludeFilter) {
+        if (Test-NameMatchesPattern -Name $WorkspaceName -Pattern $pattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Import-BackupConfig {
+    <#
+    .SYNOPSIS
+        Reads a JSON configuration file and returns its contents as a hashtable.
+    .OUTPUTS
+        A hashtable of configuration values, or an empty hashtable if the file is not found.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        return @{}
+    }
+
+    $content = Get-Content -Path $Path -Raw
+    $json = $content | ConvertFrom-Json
+
+    # Convert PSCustomObject to hashtable
+    $config = @{}
+    foreach ($prop in $json.PSObject.Properties) {
+        $config[$prop.Name] = $prop.Value
+    }
+
+    return $config
+}
+
+function Get-CapacityIdsByName {
+    <#
+    .SYNOPSIS
+        Resolves capacity display names (with wildcard support) to capacity IDs.
+    .OUTPUTS
+        An array of matching capacity ID strings.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$CapacityFilter,
+
+        [string]$LogFilePath
+    )
+
+    $allCapacities = Get-PowerBICapacity -Scope Organization
+
+    if (-not $allCapacities) {
+        Write-Log -Message "No capacities found in the organization." -Level Warning -LogFilePath $LogFilePath
+        return @()
+    }
+
+    $matched = @()
+    foreach ($capacity in $allCapacities) {
+        foreach ($pattern in $CapacityFilter) {
+            if (Test-NameMatchesPattern -Name $capacity.DisplayName -Pattern $pattern) {
+                $matched += $capacity
+                break
+            }
+        }
+    }
+
+    if ($matched.Count -eq 0) {
+        Write-Log -Message "No capacities matched the filter: $($CapacityFilter -join ', ')" -Level Warning -LogFilePath $LogFilePath
+        return @()
+    }
+
+    foreach ($cap in $matched) {
+        Write-Log -Message "Matched capacity: $($cap.DisplayName) (ID: $($cap.Id))" -Level Info -LogFilePath $LogFilePath
+    }
+
+    return $matched | ForEach-Object { $_.Id }
+}
+
+function Test-DatasetMatchesFilter {
+    <#
+    .SYNOPSIS
+        Checks if a dataset name matches an include filter.
+    .OUTPUTS
+        $true if the dataset should be processed.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DatasetName,
+
+        [string[]]$IncludeFilter
+    )
+
+    if (-not $IncludeFilter -or $IncludeFilter.Count -eq 0) {
+        return $true
+    }
+
+    foreach ($pattern in $IncludeFilter) {
+        if (Test-NameMatchesPattern -Name $DatasetName -Pattern $pattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+Export-ModuleMember -Function @(
+    'Write-Log'
+    'Connect-PBIServiceAuthenticated'
+    'Get-PBIAccessTokenString'
+    'Get-TenantDataflowStorageId'
+    'Connect-WorkspaceToDataflowStorage'
+    'Test-WorkspaceMatchesFilter'
+    'Test-DatasetMatchesFilter'
+    'Import-BackupConfig'
+    'Get-CapacityIdsByName'
+)

--- a/scripts/pbi-adls-backup/README.md
+++ b/scripts/pbi-adls-backup/README.md
@@ -1,0 +1,425 @@
+# Power BI Semantic Model Backup & Restore
+
+Automates backing up and restoring Power BI Semantic Models (`.abf` files) via the XMLA endpoint to an ADLS Gen2 storage account attached at the tenant level.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Step-by-Step Setup](#step-by-step-setup)
+3. [Project Structure](#project-structure)
+4. [Usage — Backup](#usage--backup)
+5. [Usage — Restore](#usage--restore)
+6. [Parameters Reference](#parameters-reference)
+7. [Configuration](#configuration)
+8. [How Backups Work](#how-backups-work)
+9. [How Restores Work](#how-restores-work)
+10. [Logging](#logging)
+11. [Troubleshooting](#troubleshooting)
+12. [Known Limitations](#known-limitations)
+13. [Running Tests](#running-tests)
+14. [Future Enhancements](#future-enhancements)
+
+---
+
+## Prerequisites
+
+Before using these scripts, ensure you have the following:
+
+| # | Requirement | Details |
+|---|---|---|
+| 1 | **PowerShell 7.0+** | PowerShell 7.x is recommended. Version 5.1 may work but is not tested. |
+| 2 | **MicrosoftPowerBIMgmt module** | Provides `Connect-PowerBIServiceAccount`, `Get-PowerBIWorkspace`, `Get-PowerBIDataset`, etc. |
+| 3 | **SqlServer module** | Provides `Invoke-ASCmd` for executing TMSL commands against the XMLA endpoint. |
+| 4 | **Premium or Fabric capacity** | The XMLA endpoint is only available on Premium Per User (PPU), Premium, or Fabric capacities. |
+| 5 | **ADLS Gen2 storage account** | Must be attached at the tenant level in the Power BI Admin Portal. Hierarchical namespace **must** be enabled. |
+| 6 | **Permissions** | Power BI Service Admin (required for the `Organization` scope used to enumerate workspaces) **or** workspace-level Admin on each target workspace. |
+
+---
+
+## Step-by-Step Setup
+
+Follow these steps in order to prepare your environment.
+
+### Step 1 — Install PowerShell 7
+
+If you don't already have PowerShell 7 installed:
+
+```powershell
+# On Windows, install via winget:
+winget install Microsoft.PowerShell
+
+# Verify:
+pwsh --version
+# Expected output: PowerShell 7.x.x
+```
+
+> **Tip:** Always run these scripts in `pwsh` (PowerShell 7), not the legacy `powershell.exe` (5.1).
+
+### Step 2 — Install Required PowerShell Modules
+
+Open a PowerShell 7 terminal and run:
+
+```powershell
+# Install the Power BI Management module (includes Profile, Workspaces, Data sub-modules)
+Install-Module -Name MicrosoftPowerBIMgmt -Scope CurrentUser -Force
+
+# Install the SqlServer module (provides Invoke-ASCmd)
+Install-Module -Name SqlServer -Scope CurrentUser -Force
+```
+
+**Verify the installation:**
+
+```powershell
+# Check that all required cmdlets are available
+Get-Command Connect-PowerBIServiceAccount   # from MicrosoftPowerBIMgmt.Profile
+Get-Command Get-PowerBIWorkspace             # from MicrosoftPowerBIMgmt.Workspaces
+Get-Command Get-PowerBIDataset               # from MicrosoftPowerBIMgmt.Data
+Get-Command Invoke-ASCmd                     # from SqlServer
+```
+
+If any command is not found, install the specific sub-module:
+
+```powershell
+Install-Module -Name MicrosoftPowerBIMgmt.Profile -Scope CurrentUser -Force
+Install-Module -Name MicrosoftPowerBIMgmt.Workspaces -Scope CurrentUser -Force
+Install-Module -Name MicrosoftPowerBIMgmt.Data -Scope CurrentUser -Force
+```
+
+### Step 3 — Configure ADLS Gen2 Storage (Tenant-Level)
+
+1. Open the **Power BI Admin Portal** (https://app.powerbi.com → Settings gear → Admin portal).
+2. Go to **Tenant settings** → search for "*Allow workspace admins to assign workspaces to dataflow storage accounts*" → **Enable** it.
+3. Go to **Azure connections** → **Tenant-level storage** → click **Add connection**.
+4. Select your **ADLS Gen2 storage account**.
+
+> **Important:** The storage account **must** have **Hierarchical namespace** enabled (this is configured at storage account creation and cannot be changed afterwards).
+
+### Step 4 — Enable XMLA Read/Write on Your Capacity
+
+1. In the **Power BI Admin Portal**, go to **Capacity settings**.
+2. Select your Premium or Fabric capacity.
+3. Under **Workloads** (or **XMLA Endpoint**), set the XMLA endpoint to **Read Write**.
+
+Without this, backup and restore commands will fail with connection errors.
+
+### Step 5 — Clone This Repository
+
+```powershell
+git clone <repository-url>
+cd PowerShellPBIBackup
+```
+
+---
+
+## Project Structure
+
+```
+PowerShellPBIBackup/
+├── Backup-PBISemanticModels.ps1    # Main backup script
+├── Restore-PBISemanticModels.ps1   # Main restore script
+├── PBIBackupHelpers.psm1           # Shared helper module (auto-imported by scripts)
+├── config.example.json             # Example configuration (copy to config.json and edit)
+└── README.md
+```
+
+---
+
+## Usage — Backup
+
+The backup script loads settings from `config.json` (if present), with CLI parameters overriding config values. It iterates through Premium/Fabric workspaces, connects each to the tenant's ADLS Gen2 storage, and triggers an XMLA backup for each semantic model.
+
+### Interactive Login — All Workspaces
+
+```powershell
+.\Backup-PBISemanticModels.ps1
+```
+
+A browser window will open for you to sign in to Power BI. After authentication, the script processes every dedicated-capacity workspace.
+
+### Filter by Capacity Name (Wildcards Supported)
+
+```powershell
+.\Backup-PBISemanticModels.ps1 -CapacityFilter "Sales Premium", "Finance*"
+```
+
+- `-CapacityFilter` — only process workspaces on capacities whose display names match these patterns.
+- If omitted, all dedicated-capacity workspaces are processed regardless of which capacity they belong to.
+
+### Filter by Workspace Name (Wildcards Supported)
+
+```powershell
+.\Backup-PBISemanticModels.ps1 -WorkspaceFilter "Sales*", "Finance*" -ExcludeWorkspaces "Sales Archive"
+```
+
+- `-WorkspaceFilter` — only process workspaces whose names match these patterns.
+- `-ExcludeWorkspaces` — skip workspaces matching these patterns (evaluated first).
+
+Capacity and workspace filters can be combined — capacity filtering is applied first, then workspace name filtering.
+
+### Filter by Semantic Model Name
+
+```powershell
+.\Backup-PBISemanticModels.ps1 -DatasetFilter "Revenue Model", "Cost*"
+```
+
+### Custom Config File
+
+```powershell
+.\Backup-PBISemanticModels.ps1 -ConfigFilePath "C:\configs\production.json"
+```
+
+### Custom Log File Path
+
+```powershell
+.\Backup-PBISemanticModels.ps1 -LogFilePath "C:\Logs\pbi_backup.log"
+```
+
+### Preview Mode (No Changes)
+
+```powershell
+.\Backup-PBISemanticModels.ps1 -WorkspaceFilter "Test*" -WhatIf
+```
+
+`-WhatIf` shows what would happen without making any changes — no ADLS assignments, no backups.
+
+---
+
+## Usage — Restore
+
+The restore script supports three modes. The target workspace **must** be on Premium or Fabric capacity.
+
+Modes 2 and 3 rely on the backup success CSV logs (`Backup_*_successes.csv`) written by the backup script. These CSVs record the exact `.abf` filename for each successful backup, so the restore script can look up the correct file automatically.
+
+### Mode 1 — Restore a Specific Backup File
+
+You specify the exact `.abf` filename. This is useful when you need to restore from a specific point in time.
+
+```powershell
+.\Restore-PBISemanticModels.ps1 `
+    -WorkspaceName "Sales Analytics" `
+    -DatasetName "Sales Model" `
+    -BackupFileName "Sales Model_20260305_140000.abf" `
+    -AllowOverwrite
+```
+
+| Parameter | Purpose |
+|---|---|
+| `-WorkspaceName` | The workspace to restore into |
+| `-DatasetName` | The name for the restored semantic model |
+| `-BackupFileName` | The exact `.abf` filename in ADLS storage |
+| `-AllowOverwrite` | Overwrite the model if it already exists |
+
+If you omit `-DatasetName`, the script derives it from the filename (strips the `_yyyyMMdd_HHmmss.abf` suffix).
+
+### Mode 2 — Restore a Single Model (Latest Backup)
+
+```powershell
+.\Restore-PBISemanticModels.ps1 `
+    -WorkspaceName "Sales Analytics" `
+    -DatasetName "Sales Model" `
+    -AllowOverwrite
+```
+
+The script finds the most recent `Backup_*_successes.csv` in the log directory and looks up the `.abf` filename for `Sales Model` in the `Sales Analytics` workspace.
+
+### Mode 3 — Bulk Restore (All Models in Workspace)
+
+```powershell
+.\Restore-PBISemanticModels.ps1 `
+    -WorkspaceName "Sales Analytics" `
+    -AllowOverwrite
+```
+
+Restores every semantic model for the given workspace found in the latest backup success CSV. If a model appears more than once, the last entry is used.
+
+### Custom Config File
+
+```powershell
+.\Restore-PBISemanticModels.ps1 -WorkspaceName "Sales Analytics" `
+    -ConfigFilePath "C:\configs\production.json" -AllowOverwrite
+```
+
+### Preview Mode
+
+```powershell
+.\Restore-PBISemanticModels.ps1 -WorkspaceName "Sales Analytics" -AllowOverwrite -WhatIf
+```
+
+---
+
+## Parameters Reference
+
+### Backup-PBISemanticModels.ps1
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `-ConfigFilePath` | string | No | Path to JSON config file. Default: `./config.json`. Config values are used as defaults; CLI params override. |
+| `-CapacityFilter` | string[] | No | Capacity display name patterns to include (wildcards OK). Omit to process all capacities. |
+| `-DataflowStorageAccountName` | string | No | Display name (or wildcard pattern) of the ADLS Gen2 storage account. Omit to use the first tenant-level account. |
+| `-WorkspaceFilter` | string[] | No | Workspace name patterns to include (wildcards OK). Omit to process all. |
+| `-ExcludeWorkspaces` | string[] | No | Workspace name patterns to exclude (evaluated before include filter). |
+| `-DatasetFilter` | string[] | No | Semantic model name patterns to include (wildcards OK). Omit to back up all. |
+| `-LogFilePath` | string | No | Path to log file. Default: `./logs/Backup_<timestamp>.log` |
+| `-WhatIf` | switch | No | Preview mode — shows what would happen without making changes. |
+
+### Restore-PBISemanticModels.ps1
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `-ConfigFilePath` | string | No | Path to JSON config file. Default: `./config.json`. Used to read `logDirectory`. |
+| `-WorkspaceName` | string | **Yes** | Name of the target workspace to restore into. |
+| `-DatasetName` | string | No | Name of the semantic model to restore. |
+| `-BackupFileName` | string | No | Exact `.abf` filename to restore from ADLS storage. |
+| `-AllowOverwrite` | switch | No | Overwrite an existing model with the same name. |
+| `-LogFilePath` | string | No | Path to log file. Default: `./logs/Restore_<timestamp>.log` |
+| `-WhatIf` | switch | No | Preview mode — shows what would happen without making changes. |
+
+---
+
+## Configuration
+
+The backup script automatically loads `config.json` from the script directory (if it exists). CLI parameters override any values from the config file. This means you can set your standard options in the config and only pass overrides on the command line.
+
+To create your config file:
+
+```powershell
+Copy-Item config.example.json config.json
+# Edit config.json with your values (this file is git-ignored)
+```
+
+### Config File Schema
+
+```json
+{
+  "capacityNames": ["Sales Premium", "Finance*"],
+  "dataflowStorageAccountName": "adlsproduction",
+  "workspaceFilter": ["Sales*", "Finance*"],
+  "excludeWorkspaces": ["*Archive*"],
+  "datasetFilter": [],
+  "logDirectory": "./logs"
+}
+```
+
+| Key | Type | Maps to CLI Parameter | Description |
+|---|---|---|---|
+| `capacityNames` | string[] | `-CapacityFilter` | Capacity display names to include (wildcards OK). |
+| `dataflowStorageAccountName` | string | `-DataflowStorageAccountName` | Display name (or wildcard) of the ADLS Gen2 storage account. |
+| `workspaceFilter` | string[] | `-WorkspaceFilter` | Workspace name patterns to include. |
+| `excludeWorkspaces` | string[] | `-ExcludeWorkspaces` | Workspace name patterns to exclude. |
+| `datasetFilter` | string[] | `-DatasetFilter` | Semantic model name patterns to include. |
+| `logDirectory` | string | `-LogFilePath` | Directory for log files. |
+
+### Merge Behavior
+
+- If a CLI parameter is explicitly provided, it **always wins** over the config value.
+- If a CLI parameter is not provided, the config value is used.
+- If neither is provided, the built-in default applies.
+- Use `-ConfigFilePath` to point to a different config file (e.g., per-environment configs).
+
+---
+
+## How Backups Work
+
+1. The script loads `config.json` (if present) and merges with CLI parameters.
+2. It authenticates to Power BI (interactive login).
+3. It retrieves the tenant-level ADLS Gen2 Dataflow Storage Account ID (matching by name if `dataflowStorageAccountName` is configured).
+4. It fetches all dedicated-capacity workspaces, then applies filters in order:
+   - **Capacity filter** — if `capacityNames` is set, only workspaces on matching capacities are kept.
+   - **Workspace name filter** — include/exclude patterns further narrow the list.
+5. For each remaining workspace:
+   - Assigns the workspace to the ADLS storage account (skipped if already assigned).
+   - For each semantic model (matching dataset filters):
+     - Sends a TMSL `backup` command via the XMLA endpoint.
+     - The Power BI service writes the `.abf` file to the ADLS Gen2 storage.
+6. A summary is logged showing total workspaces processed, models backed up, and any failures.
+
+Backup files follow the naming convention: **`<ModelName>_<yyyyMMdd_HHmmss>.abf`**
+
+---
+
+## How Restores Work
+
+1. The script loads `config.json` (if present) for the `logDirectory` setting.
+2. It authenticates to Power BI (interactive login) and looks up the target workspace.
+3. It verifies the workspace is on a dedicated capacity (Premium/Fabric).
+4. Depending on the parameters provided, it runs in one of three modes:
+   - **Mode 1** (`-BackupFileName` provided): Restores that exact file.
+   - **Mode 2** (`-DatasetName` only): Finds the most recent `Backup_*_successes.csv` in the log directory and looks up the matching `.abf` filename.
+   - **Mode 3** (neither provided): Reads the latest backup success CSV and restores all models that match the target workspace.
+5. For modes 2 and 3, the access token is refreshed before each restore to avoid staleness during long runs.
+6. Each restore sends a TMSL `restore` command via the XMLA endpoint.
+7. Results are recorded to `Restore_<timestamp>_successes.csv` and `Restore_<timestamp>_failures.csv`.
+8. A summary is logged showing attempted, successful, and failed restores.
+
+---
+
+## Logging
+
+All operations are logged to both the **console** and a **timestamped log file**.
+
+- **Default log location:** `./logs/Backup_<yyyyMMdd_HHmmss>.log` or `./logs/Restore_<yyyyMMdd_HHmmss>.log`
+- **Override:** Pass `-LogFilePath "C:\your\path\logfile.log"` to either script.
+- **Log format:** `[yyyy-MM-dd HH:mm:ss] [Level] Message`
+- **Log levels:** `Info`, `Success`, `Warning`, `Error`
+
+Both scripts also generate CSV summary logs alongside the main log:
+
+- `Backup_<timestamp>_successes.csv` / `Backup_<timestamp>_failures.csv`
+- `Restore_<timestamp>_successes.csv` / `Restore_<timestamp>_failures.csv`
+
+Success CSVs include columns: `Workspace`, `SemanticModel`, `BackupFileName`. Failure CSVs add an `Error` column.
+
+The restore script (modes 2 and 3) uses the backup success CSVs to look up the `.abf` filenames for the latest backup run.
+
+The `logs/` directory is created automatically if it doesn't exist. The directory is included in `.gitignore`.
+
+---
+
+## Troubleshooting
+
+| # | Issue | Resolution |
+|---|---|---|
+| 1 | **"No Dataflow Storage Accounts found"** | Attach an ADLS Gen2 account in the Power BI Admin Portal → Azure connections → Tenant-level storage. |
+| 2 | **403 Forbidden on AssignToDataflowStorage** | Ensure your account has **Admin** access on the workspace. Verify the tenant setting *"Allow workspace admins to assign workspaces to dataflow storage accounts"* is enabled. |
+| 3 | **XMLA endpoint connection failed** | Verify: (a) the workspace is on Premium/Fabric capacity, (b) the XMLA endpoint is set to **Read Write** in capacity settings, and (c) the workspace name doesn't contain special characters that break the endpoint URL. |
+| 4 | **"Connect-PowerBIServiceAccount is not recognized"** | The `MicrosoftPowerBIMgmt.Profile` module is not installed. Run `Install-Module -Name MicrosoftPowerBIMgmt -Scope CurrentUser -Force`. |
+| 5 | **"Invoke-ASCmd is not recognized"** | The `SqlServer` module is not installed. Run `Install-Module -Name SqlServer -Scope CurrentUser -Force`. |
+| 6 | **Token expired during long runs** | For large tenants with many workspaces, use `-WorkspaceFilter` to process subsets in separate runs. |
+| 7 | **Backup file not found during restore** | Modes 2 & 3 look up filenames from the latest `Backup_*_successes.csv`. If no CSV exists, run a backup first or use Mode 1 with `-BackupFileName`. |
+| 8 | **"Workspace 'X' is not on a dedicated capacity"** | The target workspace must be assigned to a Premium or Fabric capacity. Move the workspace to a capacity in the Power BI Admin Portal. |
+| 9 | **#Requires module not found** | If you see `The following modules could not be loaded`, install the specific sub-module: `Install-Module -Name MicrosoftPowerBIMgmt.Profile -Scope CurrentUser -Force` (repeat for `.Workspaces`, `.Data`). |
+
+
+---
+
+## Known Limitations
+
+1. **Restore modes 2 & 3 require backup success CSVs.** The restore script finds `.abf` filenames from `Backup_*_successes.csv` files in the log directory. If no CSV exists (e.g., first-time restore from a different machine), use Mode 1 with `-BackupFileName`.
+2. **Sequential processing.** Workspaces and models are processed one at a time. For tenants with many workspaces, consider running multiple filtered batches.
+3. **Workspace names with special characters.** The XMLA endpoint URL uses the workspace name directly. Names with certain special characters may cause connection failures.
+
+---
+
+## Running Tests
+
+Unit tests are located in `Tests/PBIBackupHelpers.Tests.ps1` and use [Pester](https://pester.dev/) v5+.
+
+```powershell
+# Install Pester (if not already installed)
+Install-Module -Name Pester -Scope CurrentUser -Force -MinimumVersion 5.0
+
+# Run the tests
+Invoke-Pester -Path ./Tests/ -Output Detailed
+```
+
+---
+
+## Future Enhancements
+
+- Parallel backup execution for large tenants
+- Automatic backup retention / pruning
+- Incremental backup support
+- Scheduled task / Azure Automation runbook examples
+- Email / Teams notification on backup failures

--- a/scripts/pbi-adls-backup/Restore-PBISemanticModels.ps1
+++ b/scripts/pbi-adls-backup/Restore-PBISemanticModels.ps1
@@ -1,0 +1,310 @@
+#Requires -Modules MicrosoftPowerBIMgmt.Profile, MicrosoftPowerBIMgmt.Workspaces, MicrosoftPowerBIMgmt.Data, SqlServer
+
+<#
+.SYNOPSIS
+    Restores Power BI Semantic Models from .abf backup files via the XMLA endpoint.
+
+.DESCRIPTION
+    Restores one or more semantic models into a specified workspace using TMSL restore
+    commands executed against the XMLA endpoint. Supports three modes:
+
+    - Explicit file:   Provide -BackupFileName to restore a specific .abf file.
+    - Single model:    Provide -DatasetName only — the script finds the latest backup
+                       for that model from the most recent backup success CSV.
+    - Bulk restore:    Omit both — restores all models from the latest backup success CSV
+                       that match the target workspace.
+
+    The workspace must be on a Premium or Fabric capacity (XMLA endpoint requirement).
+
+.PARAMETER ConfigFilePath
+    Optional. Path to a JSON configuration file. Defaults to ./config.json.
+    Used to read the logDirectory setting.
+
+.PARAMETER WorkspaceName
+    Required. The name of the target workspace to restore into.
+
+.PARAMETER DatasetName
+    Optional. The name of the semantic model to restore. When combined with
+    -BackupFileName, restores that specific file as this model.
+
+.PARAMETER BackupFileName
+    Optional. The exact .abf filename to restore (e.g., "Sales_20260301_120000.abf").
+    When provided, performs a single restore operation.
+
+.PARAMETER AllowOverwrite
+    Switch. When set, the restore will overwrite an existing model with the same name.
+
+.PARAMETER LogFilePath
+    Optional. Path to a log file. Defaults to ./logs/Restore_<timestamp>.log.
+
+.EXAMPLE
+    # Restore a single backup interactively
+    .\Restore-PBISemanticModels.ps1 -WorkspaceName "Sales Analytics" `
+        -DatasetName "Sales Model" -BackupFileName "Sales Model_20260301_120000.abf" -AllowOverwrite
+
+.EXAMPLE
+    # Restore a single model using the latest backup
+    .\Restore-PBISemanticModels.ps1 -WorkspaceName "Sales Analytics" -DatasetName "Sales Model" -AllowOverwrite
+
+.EXAMPLE
+    # Bulk-restore all models from the latest backup
+    .\Restore-PBISemanticModels.ps1 -WorkspaceName "Sales Analytics" -AllowOverwrite
+
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ConfigFilePath,
+
+    [Parameter(Mandatory)]
+    [string]$WorkspaceName,
+
+    [string]$DatasetName,
+
+    [string]$BackupFileName,
+
+    [switch]$AllowOverwrite,
+
+    [string]$LogFilePath
+)
+
+# --- Setup ---
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $scriptDir "PBIBackupHelpers.psm1") -Force
+
+# --- Load Config ---
+if (-not $ConfigFilePath) {
+    $ConfigFilePath = Join-Path $scriptDir "config.json"
+}
+$config = Import-BackupConfig -Path $ConfigFilePath
+
+$logTimestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+
+if (-not $LogFilePath) {
+    $logDir = if ($config.logDirectory) { $config.logDirectory } else { Join-Path $scriptDir "logs" }
+    $LogFilePath = Join-Path $logDir ("Restore_{0}.log" -f $logTimestamp)
+}
+else {
+    $logDir = Split-Path -Path $LogFilePath -Parent
+}
+
+# Derive success/failure CSV log paths using the same timestamp
+$SuccessLogPath = Join-Path $logDir ("Restore_{0}_successes.csv" -f $logTimestamp)
+$FailureLogPath = Join-Path $logDir ("Restore_{0}_failures.csv" -f $logTimestamp)
+
+# Ensure log directory exists and write CSV headers
+if ($logDir -and -not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+Set-Content -Path $SuccessLogPath -Value '"Workspace","SemanticModel","BackupFileName"'
+Set-Content -Path $FailureLogPath -Value '"Workspace","SemanticModel","BackupFileName","Error"'
+
+$totalAttempted = 0
+$totalSuccess = 0
+$totalFailed = 0
+
+# --- Authenticate ---
+Write-Log -Message "=== Power BI Semantic Model Restore ===" -Level Info -LogFilePath $LogFilePath
+
+Write-Log -Message "Authenticating to Power BI Service..." -Level Info -LogFilePath $LogFilePath
+$token = Connect-PBIServiceAuthenticated
+Write-Log -Message "Authentication successful." -Level Success -LogFilePath $LogFilePath
+
+# --- Resolve Workspace ---
+Write-Log -Message "Looking up workspace '$WorkspaceName'..." -Level Info -LogFilePath $LogFilePath
+$workspace = Get-PowerBIWorkspace -Scope Organization -Name $WorkspaceName
+
+if (-not $workspace) {
+    Write-Log -Message "Workspace '$WorkspaceName' not found." -Level Error -LogFilePath $LogFilePath
+    throw "Workspace '$WorkspaceName' not found."
+}
+
+if (-not $workspace.IsOnDedicatedCapacity) {
+    Write-Log -Message "Workspace '$WorkspaceName' is not on a dedicated capacity. XMLA restore requires Premium or Fabric." -Level Error -LogFilePath $LogFilePath
+    throw "Workspace '$WorkspaceName' is not on a dedicated capacity."
+}
+
+Write-Log -Message "Workspace found: $($workspace.Name) (ID: $($workspace.Id))" -Level Success -LogFilePath $LogFilePath
+
+# --- Build XMLA Connection ---
+$xmlaEndpoint = "powerbi://api.powerbi.com/v1.0/myorg/$($workspace.Name)"
+$connectionString = "DataSource=$xmlaEndpoint;Password=$token;"
+
+$overwriteFlag = if ($AllowOverwrite) { "true" } else { "false" }
+
+# --- Helper: Find latest backup success CSV ---
+function Get-LatestBackupManifest {
+    param([string]$LogDirectory)
+
+    $csvFiles = Get-ChildItem -Path $LogDirectory -Filter "Backup_*_successes.csv" -File -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending
+
+    if (-not $csvFiles) { return $null }
+
+    return $csvFiles[0].FullName
+}
+
+# --- Helper: Execute a single restore ---
+function Invoke-SingleRestore {
+    param(
+        [string]$TargetName,
+        [string]$File,
+        [string]$ConnString,
+        [string]$Overwrite,
+        [string]$Log,
+        [string]$SuccessLog,
+        [string]$FailureLog,
+        [string]$WsName
+    )
+
+    $escapedName = $TargetName -replace '\\', '\\\\' -replace '"', '\"'
+    $escapedFile = $File -replace '\\', '\\\\' -replace '"', '\"'
+
+    $tmsl = @"
+{
+  "restore": {
+    "database": "$escapedName",
+    "file": "$escapedFile",
+    "allowOverwrite": $Overwrite
+  }
+}
+"@
+
+    if ($script:PSCmdlet.ShouldProcess("$TargetName in $WsName", "XMLA Restore from $File")) {
+        try {
+            Write-Log -Message "  Restoring '$TargetName' from '$File'..." -Level Info -LogFilePath $Log
+            $result = Invoke-ASCmd -ConnectionString $ConnString -Query $tmsl -ErrorAction Stop
+            if ($result -match '<Error.*?Description="([^"]*)"') {
+                Write-Log -Message "  XMLA error restoring '$TargetName': $($Matches[1])" -Level Error -LogFilePath $Log
+                $eWs = $WsName -replace '"', '""'
+                $eDs = $TargetName -replace '"', '""'
+                $eBf = $File -replace '"', '""'
+                $eErr = $Matches[1] -replace '"', '""'
+                Add-Content -Path $FailureLog -Value ('"' + $eWs + '","' + $eDs + '","' + $eBf + '","' + $eErr + '"')
+                $script:totalFailed++
+            }
+            else {
+                Write-Log -Message "  Restore successful: $TargetName" -Level Success -LogFilePath $Log
+                $eWs = $WsName -replace '"', '""'
+                $eDs = $TargetName -replace '"', '""'
+                $eBf = $File -replace '"', '""'
+                Add-Content -Path $SuccessLog -Value ('"' + $eWs + '","' + $eDs + '","' + $eBf + '"')
+                $script:totalSuccess++
+            }
+        }
+        catch {
+            Write-Log -Message "  Failed to restore '$TargetName'. Error: $_" -Level Error -LogFilePath $Log
+            $eWs = $WsName -replace '"', '""'
+            $eDs = $TargetName -replace '"', '""'
+            $eBf = $File -replace '"', '""'
+            $eErr = $_.Exception.Message -replace '"', '""'
+            Add-Content -Path $FailureLog -Value ('"' + $eWs + '","' + $eDs + '","' + $eBf + '","' + $eErr + '"')
+            $script:totalFailed++
+        }
+    }
+}
+
+# --- Determine Restore Mode ---
+if ($BackupFileName) {
+    # --- Mode 1: Explicit backup file ---
+    $targetName = if ($DatasetName) { $DatasetName } else {
+        if ($BackupFileName -match '^(.+)_\d{8}_\d{6}\.abf$') {
+            $Matches[1]
+        }
+        else {
+            $BackupFileName -replace '\.abf$', ''
+        }
+    }
+
+    $totalAttempted++
+    Write-Log -Message "Restoring specific backup file: $BackupFileName" -Level Info -LogFilePath $LogFilePath
+    Invoke-SingleRestore -TargetName $targetName -File $BackupFileName -ConnString $connectionString `
+        -Overwrite $overwriteFlag -Log $LogFilePath -SuccessLog $SuccessLogPath -FailureLog $FailureLogPath `
+        -WsName $workspace.Name
+}
+elseif ($DatasetName) {
+    # --- Mode 2: Single model, find latest backup from CSV ---
+    Write-Log -Message "Looking up latest backup for '$DatasetName' in workspace '$WorkspaceName'..." -Level Info -LogFilePath $LogFilePath
+
+    $manifestPath = Get-LatestBackupManifest -LogDirectory $logDir
+    if (-not $manifestPath) {
+        Write-Log -Message "No backup success CSV found in '$logDir'. Cannot determine latest backup. Use -BackupFileName to specify explicitly." -Level Error -LogFilePath $LogFilePath
+        throw "No backup success CSV found in '$logDir'."
+    }
+
+    Write-Log -Message "Using backup manifest: $manifestPath" -Level Info -LogFilePath $LogFilePath
+    $manifest = Import-Csv -Path $manifestPath
+
+    $entry = $manifest | Where-Object { $_.Workspace -eq $WorkspaceName -and $_.SemanticModel -eq $DatasetName } | Select-Object -Last 1
+
+    if (-not $entry) {
+        Write-Log -Message "No backup found for '$DatasetName' in workspace '$WorkspaceName' in the latest backup CSV." -Level Error -LogFilePath $LogFilePath
+        throw "No backup entry found for '$DatasetName' in workspace '$WorkspaceName'."
+    }
+
+    $totalAttempted++
+    Write-Log -Message "Found backup: $($entry.BackupFileName)" -Level Info -LogFilePath $LogFilePath
+
+    # Refresh token before restore
+    $token = Get-PBIAccessTokenString
+    $connectionString = "DataSource=$xmlaEndpoint;Password=$token;"
+
+    Invoke-SingleRestore -TargetName $DatasetName -File $entry.BackupFileName -ConnString $connectionString `
+        -Overwrite $overwriteFlag -Log $LogFilePath -SuccessLog $SuccessLogPath -FailureLog $FailureLogPath `
+        -WsName $workspace.Name
+}
+else {
+    # --- Mode 3: Bulk restore from latest backup CSV ---
+    Write-Log -Message "Bulk restore mode: finding latest backups for workspace '$WorkspaceName'..." -Level Info -LogFilePath $LogFilePath
+
+    $manifestPath = Get-LatestBackupManifest -LogDirectory $logDir
+    if (-not $manifestPath) {
+        Write-Log -Message "No backup success CSV found in '$logDir'. Cannot determine latest backups. Use -BackupFileName to specify explicitly." -Level Error -LogFilePath $LogFilePath
+        throw "No backup success CSV found in '$logDir'."
+    }
+
+    Write-Log -Message "Using backup manifest: $manifestPath" -Level Info -LogFilePath $LogFilePath
+    $manifest = Import-Csv -Path $manifestPath
+
+    $entries = $manifest | Where-Object { $_.Workspace -eq $WorkspaceName }
+
+    if (-not $entries) {
+        Write-Log -Message "No backup entries found for workspace '$WorkspaceName' in the latest backup CSV." -Level Warning -LogFilePath $LogFilePath
+        return
+    }
+
+    # Keep only the last entry per model (in case of duplicates)
+    $uniqueEntries = @{}
+    foreach ($entry in $entries) {
+        $uniqueEntries[$entry.SemanticModel] = $entry
+    }
+
+    Write-Log -Message "Found $($uniqueEntries.Count) model(s) to restore." -Level Info -LogFilePath $LogFilePath
+
+    foreach ($modelName in $uniqueEntries.Keys) {
+        $entry = $uniqueEntries[$modelName]
+        $totalAttempted++
+
+        # Refresh token to avoid staleness
+        $token = Get-PBIAccessTokenString
+        $connectionString = "DataSource=$xmlaEndpoint;Password=$token;"
+
+        Invoke-SingleRestore -TargetName $modelName -File $entry.BackupFileName -ConnString $connectionString `
+            -Overwrite $overwriteFlag -Log $LogFilePath -SuccessLog $SuccessLogPath -FailureLog $FailureLogPath `
+            -WsName $workspace.Name
+    }
+}
+
+# --- Summary ---
+Write-Log -Message "=== Restore Summary ===" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Workspace            : $($workspace.Name)" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Models attempted     : $totalAttempted" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Successful restores  : $totalSuccess" -Level Success -LogFilePath $LogFilePath
+if ($totalFailed -gt 0) {
+    Write-Log -Message "Failed restores      : $totalFailed" -Level Error -LogFilePath $LogFilePath
+}
+Write-Log -Message "Log file             : $LogFilePath" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Success log          : $SuccessLogPath" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "Failure log          : $FailureLogPath" -Level Info -LogFilePath $LogFilePath
+Write-Log -Message "=== Restore Complete ===" -Level Info -LogFilePath $LogFilePath

--- a/scripts/pbi-adls-backup/config.example.json
+++ b/scripts/pbi-adls-backup/config.example.json
@@ -1,0 +1,8 @@
+{
+  "capacityNames": [],
+  "dataflowStorageAccountName": "",
+  "workspaceFilter": [],
+  "excludeWorkspaces": [],
+  "datasetFilter": [],
+  "logDirectory": "./logs"
+}


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Adds a new self-contained tool under pbi-adls-backup that automates **backing up and restoring Power BI / Fabric semantic models** (`.abf` files) via the XMLA endpoint to a tenant-attached ADLS Gen2 storage account.

The tool comprises two entry-point scripts plus a shared helper module:

- **Backup-PBISemanticModels.ps1** — enumerates dedicated-capacity (Premium/Fabric) workspaces, assigns each to the tenant's ADLS Gen2 dataflow storage, and issues a TMSL `backup` per semantic model. Supports capacity / workspace / dataset filtering (with wildcards) and include/exclude lists, `config.json` defaults overridden by CLI parameters, `-WhatIf`, and timestamped log + success/failure CSV output.
- **Restore-PBISemanticModels.ps1** — restores models via TMSL `restore` in three modes: explicit `.abf` file, latest backup for a single model, or bulk restore of all models for a workspace (resolved from the backup success-CSV manifest). Refreshes the access token before each restore for long runs.
- **PBIBackupHelpers.psm1** — shared functions for logging, authentication, config loading, capacity/workspace/dataset filtering, and ADLS storage resolution.
- **README.md** — full prerequisites, setup, usage, parameters, configuration, logging, and troubleshooting documentation.
- **config.example.json**  — example configuration template

This is a new, additive tooling contribution; no existing files in the repository are modified.

### Added
- pbi-adls-backup — Power BI semantic model backup & restore tool (Backup-PBISemanticModels.ps1, Restore-PBISemanticModels.ps1, PBIBackupHelpers.psm1, README.md, config.example.json).

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [x] Comment-based help added/updated.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated..
- [ ] Integration tests added/updated (where possible).
- [x] Documentation added/updated (where applicable).
- [x] Code follows the contribution guidelines.

