### PR TITLE
Add notebook-governance-sempy: tenant-wide lakehouse table inventory using SemPy

### DIFF
--- a/samples/notebook-governance-sempy/README.md
+++ b/samples/notebook-governance-sempy/README.md
@@ -1,0 +1,39 @@
+# Fabric Notebook API Tools
+A collection of Microsoft Fabric notebooks for tenant-wide governance, inventory, and auditing. The notebooks are built on [Semantic Link (SemPy)](https://learn.microsoft.com/en-us/python/api/semantic-link/overview) and the [Fabric REST API](https://learn.microsoft.com/en-us/rest/api/fabric/articles/), and run directly inside a Fabric notebook — no external infrastructure required.
+
+This collection will grow over time. Each notebook/file is self-contained: import or copy it, run it, query the result.
+
+## get-tables.py
+Builds a complete inventory of all tables across every workspace and lakehouse you have access to, and registers it as a Spark temporary view (`fabric_lakehouse_inventory`) for immediate SQL querying.
+
+### What it does
+- Enumerates all workspaces visible to the executing identity via `sempy.fabric.list_workspaces()`
+- Lists every lakehouse in each workspace and every table in each lakehouse
+- Collects table metadata: name, type, storage location, and format
+- Registers the result as the Spark temp view `fabric_lakehouse_inventory`
+- Prints a summary of any workspaces or lakehouses that could not be read, so inventory gaps are visible instead of silent
+
+### Requirements
+- Permissions: the inventory covers only workspaces the executing identity can access. For a true tenant-wide inventory, run under an identity with access to all workspaces
+
+### How to use
+1. Copy the code into the new notebook
+2. Run the notebook
+3. Query the inventory in a new cell:
+
+```sql
+%%sql
+SELECT workspace_name, lakehouse_name, table_name, table_type, location, format
+FROM fabric_lakehouse_inventory
+```
+
+### Known limitations
+- **Schema-enabled lakehouses are not supported** by the underlying tables API and are reported in the failure summary rather than inventoried
+- Results are scoped to the permissions of the identity running the notebook
+- Workspaces and lakehouses are scanned sequentially; very large tenants may take several minutes
+
+### Use cases
+- Locate tables matching a name pattern across the entire tenant
+- Count tables per lakehouse or workspace
+- Identify duplicate or redundant tables
+- Generate a full table inventory for governance and auditing

--- a/samples/notebook-governance-sempy/get-tables.py
+++ b/samples/notebook-governance-sempy/get-tables.py
@@ -1,0 +1,73 @@
+'''
+Quick Tutorial:
+
+1. Run Code Below
+2. Run this SQL code in a separate cell to get list of tables in the lakehouses accross all workspaces (non-schema-enabled only)
+
+%%sql
+SELECT workspace_name, lakehouse_name, table_name, table_type, location, format 
+FROM fabric_lakehouse_inventory
+'''
+
+%pip install --upgrade semantic-link
+
+import sempy.fabric as fabric
+import pandas as pd
+from pyspark.sql.types import StructType, StructField, StringType
+
+all_tables = []
+failed = []
+
+workspaces = fabric.list_workspaces()
+
+for _, ws in workspaces.iterrows():
+    ws_id = ws["Id"]
+    ws_name = ws["Name"]
+
+    try:
+        lakehouses = fabric.list_items(workspace=ws_id, item_type="Lakehouse")
+
+        for _, lh in lakehouses.iterrows():
+            lh_name = lh["Display Name"]
+
+            try:
+                df = fabric.lakehouse.list_lakehouse_tables(
+                    lakehouse=lh_name,
+                    workspace=ws_id
+                )
+                df.insert(0, "workspace_name", ws_name)
+                df.insert(1, "lakehouse_name", lh_name)
+                all_tables.append(df)
+
+            except Exception:
+                failed.append({"workspace": ws_name, "lakehouse": lh_name})
+
+    except Exception:
+        failed.append({"workspace": ws_name, "lakehouse": "N/A"})
+
+if all_tables:
+    result = pd.concat(all_tables, ignore_index=True)
+
+    # Normalize column names to lowercase with underscores
+    result.columns = [c.lower().replace(" ", "_") for c in result.columns]
+
+    inventory = result.rename(columns={
+        "name":        "table_name",
+        "type":        "table_type",
+        "format":      "format",
+        "location":    "location",
+    })[["workspace_name", "lakehouse_name", "table_name", "table_type", "location", "format"]]
+
+    spark_df = spark.createDataFrame(inventory.astype(str))
+    spark_df.createOrReplaceTempView("fabric_lakehouse_inventory")
+
+    print(f"Total tables indexed: {spark_df.count()}")
+    print("View fabric_lakehouse_inventory created. Query it with:")
+
+    display(spark.sql("SELECT workspace_name, lakehouse_name, table_name, table_type, location, format FROM fabric_lakehouse_inventory"))
+else:
+    print("No tables found.")
+
+if failed:
+    print(f"\nFailed lakehouses ({len(failed)}):")
+    display(pd.DataFrame(failed))

--- a/samples/notebook-governance-sempy/get-tables.py
+++ b/samples/notebook-governance-sempy/get-tables.py
@@ -13,7 +13,6 @@ FROM fabric_lakehouse_inventory
 
 import sempy.fabric as fabric
 import pandas as pd
-from pyspark.sql.types import StructType, StructField, StringType
 
 all_tables = []
 failed = []
@@ -39,11 +38,11 @@ for _, ws in workspaces.iterrows():
                 df.insert(1, "lakehouse_name", lh_name)
                 all_tables.append(df)
 
-            except Exception:
-                failed.append({"workspace": ws_name, "lakehouse": lh_name})
+            except Exception as e:
+                failed.append({"workspace": ws_name, "lakehouse": lh_name, "error": str(e)})
 
-    except Exception:
-        failed.append({"workspace": ws_name, "lakehouse": "N/A"})
+    except Exception as e:
+        failed.append({"workspace": ws_name, "lakehouse": "N/A", "error": str(e)})
 
 if all_tables:
     result = pd.concat(all_tables, ignore_index=True)
@@ -58,13 +57,14 @@ if all_tables:
         "location":    "location",
     })[["workspace_name", "lakehouse_name", "table_name", "table_type", "location", "format"]]
 
-    spark_df = spark.createDataFrame(inventory.astype(str))
+    spark_df = spark.createDataFrame(inventory.astype(str)).cache()
     spark_df.createOrReplaceTempView("fabric_lakehouse_inventory")
 
-    print(f"Total tables indexed: {spark_df.count()}")
+    total_tables = spark_df.count()
+    print(f"Total tables indexed: {total_tables}")
     print("View fabric_lakehouse_inventory created. Query it with:")
 
-    display(spark.sql("SELECT workspace_name, lakehouse_name, table_name, table_type, location, format FROM fabric_lakehouse_inventory"))
+    display(spark.sql("SELECT workspace_name, lakehouse_name, table_name, table_type, location, format FROM fabric_lakehouse_inventory LIMIT 100"))
 else:
     print("No tables found.")
 

--- a/samples/notebook-governance-sempy/get-tables.py
+++ b/samples/notebook-governance-sempy/get-tables.py
@@ -2,7 +2,7 @@
 Quick Tutorial:
 
 1. Run Code Below
-2. Run this SQL code in a separate cell to get list of tables in the lakehouses accross all workspaces (non-schema-enabled only)
+2. Run this SQL code in a separate cell to get list of tables in the lakehouses across all workspaces (non-schema-enabled only)
 
 %%sql
 SELECT workspace_name, lakehouse_name, table_name, table_type, location, format 


### PR DESCRIPTION
## Pull Request (PR) description

Supersedes #509 — same tool, rewritten with Semantic Link (SemPy) instead of raw Fabric REST API calls. All review feedback from #509 and #483 is incorporated.

Adds `samples/notebook-governance-sempy/` — the first of a planned set of governance notebooks built on SemPy / the Fabric REST API. This notebook builds a tenant-wide inventory of all lakehouse tables and registers it as a Spark temp view (`fabric_lakehouse_inventory`) for direct SQL querying.

Why the rewrite: `sempy.fabric` handles auth, pagination, and retries natively, reducing the code to a fraction of the REST version while staying aligned with the library Microsoft ships in Fabric notebooks.

### Added
- `samples/notebook-governance-sempy/` — notebook + README (usage, output schema, example queries, known limitations)

## Task list

- [x] The PR represents a single logical change.
- [ ] CHANGELOG entry — N/A, repository has no CHANGELOG.md
- [ ] Local clean build — N/A for notebook samples
- [x] Comment-based help added/updated (quick tutorial in the notebook header)
- [x] Examples appropriately added/updated (example queries in README)
- [ ] Unit tests — N/A for notebook samples
- [x] Integration tests — manually validated in a live Fabric tenant (temp view created, failure summary reported)
- [x] Documentation added/updated (README.md)
- [x] Code follows the contribution guidelines