### PR TITLE
Fix pq-adbc-advisor accelerator notebook metadata for Fabric import

### DIFF
--- a/accelerators/pq-adbc-advisor/pq-adbc-advisor-starter.ipynb
+++ b/accelerators/pq-adbc-advisor/pq-adbc-advisor-starter.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# pq-adbc-advisor — starter notebook\n",
+    "# pq-adbc-advisor \u2014 starter notebook\n",
     "\n",
-    "Scans the currently-attached Fabric workspace and returns an item-by-item impact report for the ODBC → ADBC migration.\n",
+    "Scans the currently-attached Fabric workspace and returns an item-by-item impact report for the ODBC \u2192 ADBC migration.\n",
     "\n",
     "**This is a starting-point diagnostic, not a final audit.** Treat the report as the first pass to find the bulk of the work. For high-value production reports, validate the ADBC path in a copy of the item before flipping production over.\n",
     "\n",
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 1 — Install the package\n",
+    "## Step 1 \u2014 Install the package\n",
     "\n",
     "The tool ships as a Python package installed directly from GitHub. This installs it into the current notebook session only. A PyPI release will follow once the tool graduates from public preview."
    ]
@@ -38,7 +38,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "microsoft": {
+     "language": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "%pip install git+https://github.com/MichaelaIsaacs/pq-adbc-advisor.git@main --quiet"
@@ -48,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 2 — Scan the current workspace\n",
+    "## Step 2 \u2014 Scan the current workspace\n",
     "\n",
     "`scan_workspace()` auto-detects the workspace this notebook is attached to. It reads item definitions, walks every M expression it finds, and classifies every migrating connector call by cutover risk. It does not rewrite any M and does not trigger any refreshes."
    ]
@@ -56,7 +60,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "microsoft": {
+     "language": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "from pq_adbc_advisor import scan_workspace\n",
@@ -69,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 3 — Save the report\n",
+    "## Step 3 \u2014 Save the report\n",
     "\n",
     "This writes a self-contained HTML file that you can download from the lakehouse Files pane and share inside your org. Excerpts are secret-redacted before rendering, so it's safe to share.\n",
     "\n",
@@ -79,7 +87,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "microsoft": {
+     "language": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "output_path = report.to_html(\"/lakehouse/default/Files/pq_adbc_advisor_impact.html\")\n",
@@ -90,15 +102,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Optional — Tenant-wide scan (admin only)\n",
+    "## Optional \u2014 Tenant-wide scan (admin only)\n",
     "\n",
-    "If you have Fabric admin permissions and want to inventory every workspace in the tenant, uncomment and run the cell below. Tenant scans use the Fabric admin Scanner API and take 15–30 minutes for a mid-sized tenant."
+    "If you have Fabric admin permissions and want to inventory every workspace in the tenant, uncomment and run the cell below. Tenant scans use the Fabric admin Scanner API and take 15\u201330 minutes for a mid-sized tenant."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "microsoft": {
+     "language": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "# from pq_adbc_advisor import scan_tenant\n",
@@ -111,15 +127,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Optional — Opt out of anonymous telemetry\n",
+    "## Optional \u2014 Opt out of anonymous telemetry\n",
     "\n",
-    "Every scan sends anonymous counts to the Power Query team so we can measure adoption and prioritize connector coverage — SHA-256-hashed tenant and user identifiers only, no raw values by default. To opt out at any time, run the cell below. The opt-out is persisted across kernel restarts."
+    "Every scan sends anonymous counts to the Power Query team so we can measure adoption and prioritize connector coverage \u2014 SHA-256-hashed tenant and user identifiers only, no raw values by default. To opt out at any time, run the cell below. The opt-out is persisted across kernel restarts."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "microsoft": {
+     "language": "python"
+    }
+   },
    "outputs": [],
    "source": [
     "# from pq_adbc_advisor import disable_telemetry\n",
@@ -134,20 +154,41 @@
     "\n",
     "## Where to file\n",
     "\n",
-    "- **Bugs and feature requests:** [github.com/microsoft/fabric-toolbox/issues](https://github.com/microsoft/fabric-toolbox/issues) — tag with `pq-adbc-advisor`\n",
+    "- **Bugs and feature requests:** [github.com/microsoft/fabric-toolbox/issues](https://github.com/microsoft/fabric-toolbox/issues) \u2014 tag with `pq-adbc-advisor`\n",
     "- **Corner cases the tool flags but the standard connector doesn't cover:** adbcmigration@microsoft.com\n",
     "- **Public migration guide:** [aka.ms/adbc-migration](https://aka.ms/adbc-migration)"
    ]
   }
  ],
  "metadata": {
+  "dependencies": {},
+  "kernel_info": {
+   "name": "synapse_pyspark"
+  },
   "kernelspec": {
-   "display_name": "Synapse PySpark",
-   "language": "Python",
+   "display_name": "synapse_pyspark",
    "name": "synapse_pyspark"
   },
   "language_info": {
    "name": "python"
+  },
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "spark_compute": {
+   "compute_id": "/trident/default",
+   "session_options": {
+    "conf": {
+     "spark.synapse.nbs.session.timeout": "1200000"
+    }
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Follow-up to #645. Adds the Fabric-required metadata blocks (`microsoft`, `spark_compute`, `kernel_info`, `nteract`, `dependencies`) to the starter notebook. The DFG2-migration-accelerator sibling has these blocks — matching that shape here so the Import → From this computer flow in Fabric succeeds out of the box without the user having to hand-edit metadata.

Also normalized code cells with `execution_count`, `outputs`, and cell-level `metadata` defaults per nbformat 4.5.

## Verified end-to-end

Test imported the notebook into a workspace on Fabric MSIT (msit.powerbi.com). File validation passes with these blocks present (any remaining errors were tenant-side capacity throttling, not notebook validation).

## Diff

+59 / -18 in a single file: `accelerators/pq-adbc-advisor/pq-adbc-advisor-starter.ipynb`