### PR TITLE
Encode workspace name when constructing ABFSS path

### DIFF
--- a/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
+++ b/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
@@ -3,7 +3,7 @@ for Fabric Unified Admin Monitoring solution accelerator.
 
 --------------------------
 
-## 📦 2025.6.2
+## 📦 2026.6.2
 
 ### 📈 Enhancements
 

--- a/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
+++ b/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
@@ -2,6 +2,14 @@
 for Fabric Unified Admin Monitoring solution accelerator.
 
 --------------------------
+
+## 📦 2025.6.2
+
+### 📈 Enhancements
+
+- [Deploy_FUAM.ipynp](../scripts/Deploy_FUAM.ipynb) now includes URL encoding for workspace names with special characters i.e. spaces, special symbols, etc. to ensure compatibility with ABFSS paths.
+
+--------------------------
 ## 📦 2026.6.1
 
 Date: 2026-06-02

--- a/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
+++ b/monitoring/fabric-unified-admin-monitoring/changelog/FUAM_Changelog.md
@@ -7,7 +7,7 @@ for Fabric Unified Admin Monitoring solution accelerator.
 
 ### 📈 Enhancements
 
-- [Deploy_FUAM.ipynp](../scripts/Deploy_FUAM.ipynb) now includes URL encoding for workspace names with special characters i.e. spaces, special symbols, etc. to ensure compatibility with ABFSS paths.
+- [Deploy_FUAM.ipynb](../scripts/Deploy_FUAM.ipynb) now includes URL encoding for workspace names with special characters i.e. spaces, special symbols, etc. to ensure compatibility with ABFSS paths.
 
 --------------------------
 ## 📦 2026.6.1

--- a/monitoring/fabric-unified-admin-monitoring/scripts/Deploy_FUAM.ipynb
+++ b/monitoring/fabric-unified-admin-monitoring/scripts/Deploy_FUAM.ipynb
@@ -111,6 +111,7 @@
     "import requests\n",
     "import zipfile\n",
     "from io import BytesIO\n",
+    "from urllib.parse import quote\n",
     "import yaml\n",
     "import sempy.fabric as fabric\n",
     "import tempfile\n",
@@ -755,7 +756,7 @@
    },
    "outputs": [],
    "source": [
-    "abfss_path = f\"abfss://{trg_workspace_name}@onelake.dfs.fabric.microsoft.com/FUAM_Config_Lakehouse.Lakehouse\"\n",
+    "abfss_path = f\"abfss://{quote(trg_workspace_name, safe='')}@onelake.dfs.fabric.microsoft.com/FUAM_Config_Lakehouse.Lakehouse\"\n",
     "\n",
     "src_file_path = \"./builtin/data/table_definitions.snappy.parquet\"\n",
     "trg_lakehouse_folder_path = abfss_path + \"/Files/table_definitions/\" \n",


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.

    PLEASE DO NOT submit PRs that contain multiple unrelated changes.
    If you have multiple changes, please submit them in separate PRs.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

    for example:

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

## Enhancements

- [Deploy_FUAM.ipynp](../scripts/Deploy_FUAM.ipynb) now includes URL encoding for workspace names with special characters i.e. spaces, special symbols, etc. to ensure compatibility with ABFSS paths.

Before the change a FUAM workspace with name `[OPS] FUAM` would resolve to an abfss path `abfss://[OPS] FUAM@onelake.dfs.fabric.microsoft.com/FUAM_Config_Lakehouse.Lakehouse` which is an invalid URL and the appropriate notebook cell would produce an error.

Now the workspace name URL encoded, the notebook works without an issue. The same example would then have following abfss path - `abfss://%5BOPS%5D%20FUAM@onelake.dfs.fabric.microsoft.com/FUAM_Config_Lakehouse.Lakehouse`

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [x] Comment-based help added/updated.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated..
- [x] Integration tests added/updated (where possible).
- [x] Documentation added/updated (where applicable).
- [x] Code follows the [contribution guidelines](../README.md#contributing).
